### PR TITLE
docs/private: convert to git submodule (nyash-private-docs)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs/private"]
+	path = docs/private
+	url = https://github.com/moe-charm/nyash-private-docs


### PR DESCRIPTION
This switches docs/private to a Git submodule pointing to https://github.com/moe-charm/nyash-private-docs.

Notes
- The private repository must be accessible to collaborators/CI to fetch submodule contents.
- After cloning: run 'git submodule update --init --recursive'.
- The previous local contents were backed up to docs/private_local_backup_YYYYMMDD-*. Not included in this PR.
