### PR TITLE
nyrt: print primitives in handle console

### DIFF
--- a/crates/nyrt/src/lib.rs
+++ b/crates/nyrt/src/lib.rs
@@ -2389,11 +2389,11 @@ pub extern "C" fn nyash_console_log_export(ptr: *const i8) -> i64 {
 // Exported as: nyash.console.log_handle(i64 handle) -> i64  
 #[export_name = "nyash.console.log_handle"]
 pub extern "C" fn nyash_console_log_handle(handle: i64) -> i64 {
-    if handle <= 0 { return 0; }
-    
     if let Some(obj) = nyash_rust::jit::rt::handles::get(handle as u64) {
         let s = obj.to_string_box().value; // 既存の統一文字列変換メソッド
         println!("{}", s);
+    } else {
+        println!("{}", handle);
     }
     0
 }
@@ -2401,11 +2401,11 @@ pub extern "C" fn nyash_console_log_handle(handle: i64) -> i64 {
 // Exported as: nyash.console.warn_handle(i64 handle) -> i64  
 #[export_name = "nyash.console.warn_handle"]
 pub extern "C" fn nyash_console_warn_handle(handle: i64) -> i64 {
-    if handle <= 0 { return 0; }
-    
     if let Some(obj) = nyash_rust::jit::rt::handles::get(handle as u64) {
         let s = obj.to_string_box().value;
         eprintln!("WARN: {}", s);
+    } else {
+        eprintln!("WARN: {}", handle);
     }
     0
 }
@@ -2413,11 +2413,11 @@ pub extern "C" fn nyash_console_warn_handle(handle: i64) -> i64 {
 // Exported as: nyash.console.error_handle(i64 handle) -> i64  
 #[export_name = "nyash.console.error_handle"]
 pub extern "C" fn nyash_console_error_handle(handle: i64) -> i64 {
-    if handle <= 0 { return 0; }
-    
     if let Some(obj) = nyash_rust::jit::rt::handles::get(handle as u64) {
         let s = obj.to_string_box().value;
         eprintln!("ERROR: {}", s);
+    } else {
+        eprintln!("ERROR: {}", handle);
     }
     0
 }
@@ -2425,11 +2425,11 @@ pub extern "C" fn nyash_console_error_handle(handle: i64) -> i64 {
 // Exported as: nyash.debug.trace_handle(i64 handle) -> i64  
 #[export_name = "nyash.debug.trace_handle"]
 pub extern "C" fn nyash_debug_trace_handle(handle: i64) -> i64 {
-    if handle <= 0 { return 0; }
-    
     if let Some(obj) = nyash_rust::jit::rt::handles::get(handle as u64) {
         let s = obj.to_string_box().value;
         eprintln!("TRACE: {}", s);
+    } else {
+        eprintln!("TRACE: {}", handle);
     }
     0
 }


### PR DESCRIPTION
## Summary
- allow console log/warn/error/trace functions to display raw numbers when no handle is found

## Testing
- `cargo test -p nyrt`

------
https://chatgpt.com/codex/tasks/task_e_68c19a081bc483338d02c66681255c2d