### PR TITLE
nyrt: add debug logging for handle console output

### DIFF
--- a/crates/nyrt/src/lib.rs
+++ b/crates/nyrt/src/lib.rs
@@ -1354,6 +1354,21 @@ pub extern "C" fn nyash_console_error_export(ptr: *const i8) -> i64 {
     0
 }
 
+// Exported as: nyash.console.log_handle(i64 handle) -> i64
+#[export_name = "nyash.console.log_handle"]
+pub extern "C" fn nyash_console_log_handle_export(handle: i64) -> i64 {
+    use nyash_rust::jit::rt::handles;
+    eprintln!("DEBUG: handle={}", handle);
+    if let Some(obj) = handles::get(handle as u64) {
+        let s = obj.to_string_box().value;
+        println!("{}", s);
+    } else {
+        eprintln!("DEBUG: handle {} not found in registry", handle);
+        println!("{}", handle);
+    }
+    0
+}
+
 // Exported as: nyash.debug.trace(i8* cstr) -> i64
 #[export_name = "nyash.debug.trace"]
 pub extern "C" fn nyash_debug_trace_export(ptr: *const i8) -> i64 {


### PR DESCRIPTION
## Summary
- add `nyash.console.log_handle` export to display handles
- emit debug logs when a handle lookup fails

## Testing
- `cargo test -p nyrt` *(fails: could not find `ObjectBuilder` in `builder`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e2664a5483338bf4db6e24f1f1a6