### PR TITLE
tokenizer: camel case token variants

### DIFF
--- a/docs/development/roadmap/phases/phase-12.7/README.md
+++ b/docs/development/roadmap/phases/phase-12.7/README.md
@@ -255,11 +255,11 @@ r=u\:_.a/:_.n
 **優先度1: 即効性の高い演算子（1週間）**
 ```rust
 // tokenizer.rs に追加
-PIPE,           // |> パイプライン
-SAFE_ACCESS,    // ?. セーフアクセス
-NULL_COALESCE,  // ?? デフォルト値
-PLUS_ASSIGN,    // += 増分代入
-MINUS_ASSIGN,   // -= 減分代入
+PipeForward,    // |> パイプライン
+QmarkDot,       // ?. セーフアクセス
+QmarkQmark,     // ?? デフォルト値
+PlusAssign,     // += 増分代入
+MinusAssign,    // -= 減分代入
 // etc...
 ```
 

--- a/docs/development/roadmap/phases/phase-12.7/implementation/implementation-final-checklist.txt
+++ b/docs/development/roadmap/phases/phase-12.7/implementation/implementation-final-checklist.txt
@@ -19,8 +19,8 @@ Phase 12.7 文法改革 - 実装前最終チェックリスト
 // ARROW => ">>"  // これは間違い！
 
 // 新規追加
-FAT_ARROW => "=>"      // peek構文用
-DOUBLE_COLON => "::"   // Parent::method用（P1だがトークンは今追加）
+FatArrow => "=>"      // peek構文用
+DoubleColon => "::"   // Parent::method用（P1だがトークンは今追加）
 ```
 
 【追加する予約語（P0）】
@@ -216,7 +216,7 @@ box Point {
 ================================================================================
 
 1. tokenizer.rs
-   - FAT_ARROW, DOUBLE_COLON追加
+   - FatArrow, DoubleColon追加
    - peek, continue, birth を予約語追加
 
 2. parser/expressions.rs

--- a/src/boxes/aot_compiler_box.rs
+++ b/src/boxes/aot_compiler_box.rs
@@ -1,25 +1,55 @@
-use crate::box_trait::{NyashBox, StringBox, BoolBox, VoidBox, BoxCore, BoxBase};
+use crate::box_trait::{BoolBox, BoxBase, BoxCore, NyashBox, StringBox};
 use std::any::Any;
 
 #[derive(Debug, Clone)]
-pub struct AotCompilerBox { base: BoxBase }
+pub struct AotCompilerBox {
+    base: BoxBase,
+}
 
-impl AotCompilerBox { pub fn new() -> Self { Self { base: BoxBase::new() } } }
+impl AotCompilerBox {
+    pub fn new() -> Self {
+        Self {
+            base: BoxBase::new(),
+        }
+    }
+}
 
 impl BoxCore for AotCompilerBox {
-    fn box_id(&self) -> u64 { self.base.id }
-    fn parent_type_id(&self) -> Option<std::any::TypeId> { self.base.parent_type_id }
-    fn fmt_box(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "AotCompilerBox") }
-    fn as_any(&self) -> &dyn Any { self }
-    fn as_any_mut(&mut self) -> &mut dyn Any { self }
+    fn box_id(&self) -> u64 {
+        self.base.id
+    }
+    fn parent_type_id(&self) -> Option<std::any::TypeId> {
+        self.base.parent_type_id
+    }
+    fn fmt_box(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AotCompilerBox")
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 }
 
 impl NyashBox for AotCompilerBox {
-    fn to_string_box(&self) -> StringBox { StringBox::new("AotCompilerBox".to_string()) }
-    fn equals(&self, other: &dyn NyashBox) -> BoolBox { BoolBox::new(other.as_any().is::<AotCompilerBox>()) }
-    fn type_name(&self) -> &'static str { "AotCompilerBox" }
-    fn clone_box(&self) -> Box<dyn NyashBox> { Box::new(Self { base: self.base.clone() }) }
-    fn share_box(&self) -> Box<dyn NyashBox> { self.clone_box() }
+    fn to_string_box(&self) -> StringBox {
+        StringBox::new("AotCompilerBox".to_string())
+    }
+    fn equals(&self, other: &dyn NyashBox) -> BoolBox {
+        BoolBox::new(other.as_any().is::<AotCompilerBox>())
+    }
+    fn type_name(&self) -> &'static str {
+        "AotCompilerBox"
+    }
+    fn clone_box(&self) -> Box<dyn NyashBox> {
+        Box::new(Self {
+            base: self.base.clone(),
+        })
+    }
+    fn share_box(&self) -> Box<dyn NyashBox> {
+        self.clone_box()
+    }
 }
 
 impl AotCompilerBox {
@@ -28,26 +58,32 @@ impl AotCompilerBox {
     pub fn compile(&self, file: &str, out: &str) -> Box<dyn NyashBox> {
         let mut cmd = match std::env::current_exe() {
             Ok(p) => std::process::Command::new(p),
-            Err(e) => return Box::new(StringBox::new(format!("ERR: current_exe(): {}", e)))
+            Err(e) => return Box::new(StringBox::new(format!("ERR: current_exe(): {}", e))),
         };
         // Propagate relevant envs (AOT/JIT observe)
-        let mut c = cmd.arg("--backend").arg("vm") // ensures runner path
-                      .arg("--compile-native")
-                      .arg("-o").arg(out)
-                      .arg(file)
-                      .envs(std::env::vars());
+        let mut c = cmd
+            .arg("--backend")
+            .arg("vm") // ensures runner path
+            .arg("--compile-native")
+            .arg("-o")
+            .arg(out)
+            .arg(file)
+            .envs(std::env::vars());
         match c.output() {
             Ok(o) => {
                 let mut s = String::new();
                 s.push_str(&String::from_utf8_lossy(&o.stdout));
                 s.push_str(&String::from_utf8_lossy(&o.stderr));
                 if !o.status.success() {
-                    s = format!("AOT FAILED (code={}):\n{}", o.status.code().unwrap_or(-1), s);
+                    s = format!(
+                        "AOT FAILED (code={}):\n{}",
+                        o.status.code().unwrap_or(-1),
+                        s
+                    );
                 }
                 Box::new(StringBox::new(s))
             }
-            Err(e) => Box::new(StringBox::new(format!("ERR: spawn compile-native: {}", e)))
+            Err(e) => Box::new(StringBox::new(format!("ERR: spawn compile-native: {}", e))),
         }
     }
 }
-

--- a/src/boxes/function_box.rs
+++ b/src/boxes/function_box.rs
@@ -1,8 +1,8 @@
-use crate::box_trait::{NyashBox, StringBox, BoolBox, BoxCore, BoxBase};
 use crate::ast::ASTNode;
-use std::collections::HashMap;
-use std::sync::{Arc, Weak};
+use crate::box_trait::{BoolBox, BoxBase, BoxCore, NyashBox, StringBox};
 use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Weak;
 
 #[derive(Debug)]
 pub struct ClosureEnv {
@@ -11,7 +11,12 @@ pub struct ClosureEnv {
 }
 
 impl ClosureEnv {
-    pub fn new() -> Self { Self { me_value: None, captures: HashMap::new() } }
+    pub fn new() -> Self {
+        Self {
+            me_value: None,
+            captures: HashMap::new(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -24,32 +29,70 @@ pub struct FunctionBox {
 
 impl FunctionBox {
     pub fn new(params: Vec<String>, body: Vec<ASTNode>) -> Self {
-        Self { params, body, env: ClosureEnv::new(), base: BoxBase::new() }
+        Self {
+            params,
+            body,
+            env: ClosureEnv::new(),
+            base: BoxBase::new(),
+        }
     }
     pub fn with_env(params: Vec<String>, body: Vec<ASTNode>, env: ClosureEnv) -> Self {
-        Self { params, body, env, base: BoxBase::new() }
+        Self {
+            params,
+            body,
+            env,
+            base: BoxBase::new(),
+        }
     }
 }
 
 impl BoxCore for FunctionBox {
-    fn box_id(&self) -> u64 { self.base.id }
-    fn parent_type_id(&self) -> Option<std::any::TypeId> { self.base.parent_type_id }
-    fn fmt_box(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FunctionBox(params={}, body={})", self.params.len(), self.body.len())
+    fn box_id(&self) -> u64 {
+        self.base.id
     }
-    fn as_any(&self) -> &dyn Any { self }
-    fn as_any_mut(&mut self) -> &mut dyn Any { self }
+    fn parent_type_id(&self) -> Option<std::any::TypeId> {
+        self.base.parent_type_id
+    }
+    fn fmt_box(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "FunctionBox(params={}, body={})",
+            self.params.len(),
+            self.body.len()
+        )
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 }
 
 impl NyashBox for FunctionBox {
-    fn clone_box(&self) -> Box<dyn NyashBox> { Box::new(self.clone()) }
-    fn share_box(&self) -> Box<dyn NyashBox> { self.clone_box() }
-    fn to_string_box(&self) -> StringBox { StringBox::new(format!("FunctionBox(params={}, captures={}, body={})", self.params.len(), self.env.captures.len(), self.body.len())) }
-    fn type_name(&self) -> &'static str { "FunctionBox" }
+    fn clone_box(&self) -> Box<dyn NyashBox> {
+        Box::new(self.clone())
+    }
+    fn share_box(&self) -> Box<dyn NyashBox> {
+        self.clone_box()
+    }
+    fn to_string_box(&self) -> StringBox {
+        StringBox::new(format!(
+            "FunctionBox(params={}, captures={}, body={})",
+            self.params.len(),
+            self.env.captures.len(),
+            self.body.len()
+        ))
+    }
+    fn type_name(&self) -> &'static str {
+        "FunctionBox"
+    }
     fn equals(&self, other: &dyn NyashBox) -> BoolBox {
         if let Some(o) = other.as_any().downcast_ref::<FunctionBox>() {
             BoolBox::new(self.box_id() == o.box_id())
-        } else { BoolBox::new(false) }
+        } else {
+            BoolBox::new(false)
+        }
     }
 }
 
@@ -57,13 +100,20 @@ impl Clone for ClosureEnv {
     fn clone(&self) -> Self {
         let me_value = self.me_value.as_ref().map(|w| Weak::clone(w));
         let mut captures: HashMap<String, Box<dyn NyashBox>> = HashMap::new();
-        for (k, v) in &self.captures { captures.insert(k.clone(), v.clone_box()); }
+        for (k, v) in &self.captures {
+            captures.insert(k.clone(), v.clone_box());
+        }
         Self { me_value, captures }
     }
 }
 
 impl Clone for FunctionBox {
     fn clone(&self) -> Self {
-        Self { params: self.params.clone(), body: self.body.clone(), env: self.env.clone(), base: BoxBase::new() }
+        Self {
+            params: self.params.clone(),
+            body: self.body.clone(),
+            env: self.env.clone(),
+            base: BoxBase::new(),
+        }
     }
 }

--- a/src/boxes/jit_stats_box.rs
+++ b/src/boxes/jit_stats_box.rs
@@ -1,15 +1,25 @@
-use crate::box_trait::{NyashBox, StringBox, BoolBox, IntegerBox, VoidBox, BoxCore, BoxBase};
+use crate::box_trait::{BoolBox, BoxBase, BoxCore, NyashBox, StringBox};
 use std::any::Any;
 
 #[derive(Debug, Clone)]
-pub struct JitStatsBox { base: BoxBase }
+pub struct JitStatsBox {
+    base: BoxBase,
+}
 
 impl JitStatsBox {
-    pub fn new() -> Self { Self { base: BoxBase::new() } }
+    pub fn new() -> Self {
+        Self {
+            base: BoxBase::new(),
+        }
+    }
     pub fn to_json(&self) -> Box<dyn NyashBox> {
         let cfg = crate::jit::config::current();
         let caps = crate::jit::config::probe_capabilities();
-        let mode = if cfg.native_bool_abi && caps.supports_b1_sig { "b1_bool" } else { "i64_bool" };
+        let mode = if cfg.native_bool_abi && caps.supports_b1_sig {
+            "b1_bool"
+        } else {
+            "i64_bool"
+        };
         let payload = serde_json::json!({
             "version": 1,
             "abi_mode": mode,
@@ -25,17 +35,37 @@ impl JitStatsBox {
 }
 
 impl BoxCore for JitStatsBox {
-    fn box_id(&self) -> u64 { self.base.id }
-    fn parent_type_id(&self) -> Option<std::any::TypeId> { self.base.parent_type_id }
-    fn fmt_box(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "JitStatsBox") }
-    fn as_any(&self) -> &dyn Any { self }
-    fn as_any_mut(&mut self) -> &mut dyn Any { self }
+    fn box_id(&self) -> u64 {
+        self.base.id
+    }
+    fn parent_type_id(&self) -> Option<std::any::TypeId> {
+        self.base.parent_type_id
+    }
+    fn fmt_box(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JitStatsBox")
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 }
 
 impl NyashBox for JitStatsBox {
-    fn to_string_box(&self) -> StringBox { StringBox::new(self.to_json().to_string_box().value) }
-    fn equals(&self, other: &dyn NyashBox) -> BoolBox { BoolBox::new(other.as_any().is::<JitStatsBox>()) }
-    fn type_name(&self) -> &'static str { "JitStatsBox" }
-    fn clone_box(&self) -> Box<dyn NyashBox> { Box::new(self.clone()) }
-    fn share_box(&self) -> Box<dyn NyashBox> { self.clone_box() }
+    fn to_string_box(&self) -> StringBox {
+        StringBox::new(self.to_json().to_string_box().value)
+    }
+    fn equals(&self, other: &dyn NyashBox) -> BoolBox {
+        BoolBox::new(other.as_any().is::<JitStatsBox>())
+    }
+    fn type_name(&self) -> &'static str {
+        "JitStatsBox"
+    }
+    fn clone_box(&self) -> Box<dyn NyashBox> {
+        Box::new(self.clone())
+    }
+    fn share_box(&self) -> Box<dyn NyashBox> {
+        self.clone_box()
+    }
 }

--- a/src/boxes/p2p_box.rs
+++ b/src/boxes/p2p_box.rs
@@ -1,49 +1,49 @@
 /*! 📡 P2PBox - Modern P2P Communication Node
- * 
+ *
  * ## 📝 概要
  * P2PBoxは現代的なP2P通信ノードを表現するBoxです。
  * 新しいアーキテクチャ（IntentBox + MessageBus + Transport）を使用し、
  * 構造化メッセージによる安全で明示的な通信を実現します。
- * 
+ *
  * ## 🎯 AI大会議決定事項準拠
  * - **個別送信のみ**: `send(to, message)` 固定API
  * - **ブロードキャスト除外**: 安全性のため完全除外
  * - **明示的API**: 関数オーバーロード不採用
  * - **構造化メッセージ**: IntentBox (name + payload) 使用
- * 
+ *
  * ## 🛠️ 利用可能メソッド
  * - `new(node_id, transport)` - ノードを作成
  * - `send(to, intent)` - 特定ノードにメッセージ送信
  * - `on(intent_name, handler)` - イベントリスナー登録
  * - `getNodeId()` - ノードID取得
  * - `isReachable(node_id)` - ノード到達可能性確認
- * 
+ *
  * ## 💡 使用例
  * ```nyash
  * // ノード作成
  * local alice = new P2PBox("alice", "inprocess")
  * local bob = new P2PBox("bob", "inprocess")
- * 
+ *
  * // 受信ハンドラ登録
  * bob.on("chat.message", function(intent, from) {
  *     print("From " + from + ": " + intent.payload.text)
  * })
- * 
+ *
  * // メッセージ送信
  * local msg = new IntentBox("chat.message", { text: "Hello P2P!" })
  * alice.send("bob", msg)
  * ```
  */
 
-use crate::box_trait::{NyashBox, StringBox, BoolBox, BoxCore, BoxBase};
+use crate::box_trait::{BoolBox, BoxBase, BoxCore, NyashBox, StringBox};
+use crate::boxes::result::ResultBox;
 use crate::boxes::IntentBox;
 use crate::method_box::MethodBox;
-use crate::boxes::result::{ResultBox, NyashResultBox};
-use crate::transport::{Transport, InProcessTransport};
+use crate::transport::{InProcessTransport, Transport};
 use std::any::Any;
-use std::sync::{RwLock, Arc};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
 
 /// P2PBox - P2P通信ノード (RwLock pattern)
 #[derive(Debug)]
@@ -72,7 +72,7 @@ impl Clone for P2PBox {
         let handlers_val = HashMap::new(); // Start fresh for cloned instance
         let last_from_val = self.last_from.read().unwrap().clone();
         let last_intent_val = self.last_intent_name.read().unwrap().clone();
-        
+
         Self {
             base: BoxBase::new(), // New unique ID for clone
             node_id: RwLock::new(node_id_val),
@@ -93,7 +93,7 @@ pub enum TransportKind {
 
 impl std::str::FromStr for TransportKind {
     type Err = String;
-    
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "inprocess" => Ok(TransportKind::InProcess),
@@ -136,28 +136,38 @@ impl P2PBox {
             {
                 if let Ok(mut t) = transport_arc_outer.write() {
                     let transport_arc_for_cb = Arc::clone(&transport_arc_outer);
-                    t.register_intent_handler("sys.ping", Box::new(move |env| {
-                        if let Ok(mut lf) = last_from.write() { *lf = Some(env.from.clone()); }
-                        if let Ok(mut li) = last_intent.write() { *li = Some(env.intent.get_name().to_string_box().value); }
-                        // Reply asynchronously to avoid deep call stacks
-                        let to = env.from.clone();
-                        let reply = crate::boxes::IntentBox::new("sys.pong".to_string(), serde_json::json!({}));
-                        let transport_arc = Arc::clone(&transport_arc_for_cb);
-                        std::thread::spawn(move || {
-                            // slight delay to avoid lock contention and ordering races
-                            std::thread::sleep(std::time::Duration::from_millis(3));
-                            if let Ok(transport) = transport_arc.read() {
-                                let _ = transport.send(&to, reply, Default::default());
+                    t.register_intent_handler(
+                        "sys.ping",
+                        Box::new(move |env| {
+                            if let Ok(mut lf) = last_from.write() {
+                                *lf = Some(env.from.clone());
                             }
-                        });
-                    }));
+                            if let Ok(mut li) = last_intent.write() {
+                                *li = Some(env.intent.get_name().to_string_box().value);
+                            }
+                            // Reply asynchronously to avoid deep call stacks
+                            let to = env.from.clone();
+                            let reply = crate::boxes::IntentBox::new(
+                                "sys.pong".to_string(),
+                                serde_json::json!({}),
+                            );
+                            let transport_arc = Arc::clone(&transport_arc_for_cb);
+                            std::thread::spawn(move || {
+                                // slight delay to avoid lock contention and ordering races
+                                std::thread::sleep(std::time::Duration::from_millis(3));
+                                if let Ok(transport) = transport_arc.read() {
+                                    let _ = transport.send(&to, reply, Default::default());
+                                }
+                            });
+                        }),
+                    );
                 };
             }
         }
 
         p2p
     }
-    
+
     /// ノードIDを取得
     pub fn get_node_id(&self) -> Box<dyn NyashBox> {
         let node_id = self.node_id.read().unwrap().clone();
@@ -177,14 +187,17 @@ impl P2PBox {
 
         // Register temporary transport-level handler for sys.pong
         if let Ok(mut t) = self.transport.write() {
-            t.register_intent_handler("sys.pong", Box::new(move |env| {
-                if active_cb.load(Ordering::SeqCst) {
-                    // record last receive for visibility
-                    // Note: we cannot access self here safely; rely on tx notify only
-                    let _ = env; // suppress unused
-                    let _ = tx.send(());
-                }
-            }));
+            t.register_intent_handler(
+                "sys.pong",
+                Box::new(move |env| {
+                    if active_cb.load(Ordering::SeqCst) {
+                        // record last receive for visibility
+                        // Note: we cannot access self here safely; rely on tx notify only
+                        let _ = env; // suppress unused
+                        let _ = tx.send(());
+                    }
+                }),
+            );
 
             // Send sys.ping
             let ping = IntentBox::new("sys.ping".to_string(), serde_json::json!({}));
@@ -199,7 +212,9 @@ impl P2PBox {
         }
 
         // Wait for pong with timeout
-        let ok = rx.recv_timeout(std::time::Duration::from_millis(timeout_ms)).is_ok();
+        let ok = rx
+            .recv_timeout(std::time::Duration::from_millis(timeout_ms))
+            .is_ok();
         active.store(false, Ordering::SeqCst);
         Box::new(BoolBox::new(ok))
     }
@@ -208,11 +223,11 @@ impl P2PBox {
     pub fn ping(&self, to: Box<dyn NyashBox>) -> Box<dyn NyashBox> {
         self.ping_with_timeout(to, 300)
     }
-    
+
     /// 特定ノードにメッセージを送信
     pub fn send(&self, to: Box<dyn NyashBox>, intent: Box<dyn NyashBox>) -> Box<dyn NyashBox> {
         let to_str = to.to_string_box().value;
-        
+
         // Extract IntentBox from the generic Box
         if let Some(intent_box) = intent.as_any().downcast_ref::<IntentBox>() {
             let transport = self.transport.read().unwrap();
@@ -221,20 +236,34 @@ impl P2PBox {
                     // Minimal loopback trace without relying on transport callbacks
                     let self_id = self.node_id.read().unwrap().clone();
                     if to_str == self_id {
-                        if let Ok(mut lf) = self.last_from.write() { *lf = Some(self_id.clone()); }
-                        if let Ok(mut li) = self.last_intent_name.write() { *li = Some(intent_box.get_name().to_string_box().value); }
+                        if let Ok(mut lf) = self.last_from.write() {
+                            *lf = Some(self_id.clone());
+                        }
+                        if let Ok(mut li) = self.last_intent_name.write() {
+                            *li = Some(intent_box.get_name().to_string_box().value);
+                        }
                     }
                     Box::new(ResultBox::new_ok(Box::new(BoolBox::new(true))))
-                },
-                Err(e) => Box::new(ResultBox::new_err(Box::new(StringBox::new(format!("{:?}", e))))),
+                }
+                Err(e) => Box::new(ResultBox::new_err(Box::new(StringBox::new(format!(
+                    "{:?}",
+                    e
+                ))))),
             }
         } else {
-            Box::new(ResultBox::new_err(Box::new(StringBox::new("Second argument must be IntentBox"))))
+            Box::new(ResultBox::new_err(Box::new(StringBox::new(
+                "Second argument must be IntentBox",
+            ))))
         }
     }
-    
+
     /// イベントハンドラーを登録
-    fn register_handler_internal(&self, intent_str: &str, handler: &Box<dyn NyashBox>, once: bool) -> Box<dyn NyashBox> {
+    fn register_handler_internal(
+        &self,
+        intent_str: &str,
+        handler: &Box<dyn NyashBox>,
+        once: bool,
+    ) -> Box<dyn NyashBox> {
         // 保存
         {
             let mut handlers = self.handlers.write().unwrap();
@@ -245,7 +274,10 @@ impl P2PBox {
         let flag = Arc::new(AtomicBool::new(true));
         {
             let mut flags = self.handler_flags.write().unwrap();
-            flags.entry(intent_str.to_string()).or_default().push(flag.clone());
+            flags
+                .entry(intent_str.to_string())
+                .or_default()
+                .push(flag.clone());
         }
         // once情報を記録
         {
@@ -265,82 +297,111 @@ impl P2PBox {
                 // capture flags map to allow removal on once
                 let flags_arc = Arc::clone(&self.handler_flags);
                 let intent_name_closure = intent_name.clone();
-                t.register_intent_handler(&intent_name, Box::new(move |env| {
-                    if flag.load(Ordering::SeqCst) {
-                        if let Ok(mut lf) = last_from.write() { *lf = Some(env.from.clone()); }
-                        if let Ok(mut li) = last_intent.write() { *li = Some(env.intent.get_name().to_string_box().value); }
-                        let _ = method_clone.invoke(vec![
-                            Box::new(env.intent.clone()),
-                            Box::new(StringBox::new(env.from.clone())),
-                        ]);
-                        if once {
-                            flag.store(false, Ordering::SeqCst);
-                            if let Ok(mut flags) = flags_arc.write() {
-                                if let Some(v) = flags.get_mut(&intent_name_closure) { v.clear(); }
+                t.register_intent_handler(
+                    &intent_name,
+                    Box::new(move |env| {
+                        if flag.load(Ordering::SeqCst) {
+                            if let Ok(mut lf) = last_from.write() {
+                                *lf = Some(env.from.clone());
+                            }
+                            if let Ok(mut li) = last_intent.write() {
+                                *li = Some(env.intent.get_name().to_string_box().value);
+                            }
+                            let _ = method_clone.invoke(vec![
+                                Box::new(env.intent.clone()),
+                                Box::new(StringBox::new(env.from.clone())),
+                            ]);
+                            if once {
+                                flag.store(false, Ordering::SeqCst);
+                                if let Ok(mut flags) = flags_arc.write() {
+                                    if let Some(v) = flags.get_mut(&intent_name_closure) {
+                                        v.clear();
+                                    }
+                                }
                             }
                         }
-                    }
-                }));
+                    }),
+                );
             // FunctionBox ハンドラー（関数値）
-            } else if let Some(func_box) = handler.as_any().downcast_ref::<crate::boxes::function_box::FunctionBox>() {
+            } else if let Some(func_box) = handler
+                .as_any()
+                .downcast_ref::<crate::boxes::function_box::FunctionBox>()
+            {
                 let func_clone = func_box.clone();
                 let intent_name = intent_str.to_string();
                 let last_from = Arc::clone(&self.last_from);
                 let last_intent = Arc::clone(&self.last_intent_name);
                 let flags_arc = Arc::clone(&self.handler_flags);
                 let intent_name_closure = intent_name.clone();
-                t.register_intent_handler(&intent_name, Box::new(move |env| {
-                    if flag.load(Ordering::SeqCst) {
-                        if let Ok(mut lf) = last_from.write() { *lf = Some(env.from.clone()); }
-                        if let Ok(mut li) = last_intent.write() { *li = Some(env.intent.get_name().to_string_box().value); }
-                        // 最小インタープリタで FunctionBox を実行
-                        let mut interp = crate::interpreter::NyashInterpreter::new();
-                        // キャプチャ注入
-                        for (k, v) in func_clone.env.captures.iter() {
-                            interp.declare_local_variable(k, v.clone_or_share());
-                        }
-                        if let Some(me_w) = &func_clone.env.me_value {
-                            if let Some(me_arc) = me_w.upgrade() {
-                                interp.declare_local_variable("me", (*me_arc).clone_or_share());
+                t.register_intent_handler(
+                    &intent_name,
+                    Box::new(move |env| {
+                        if flag.load(Ordering::SeqCst) {
+                            if let Ok(mut lf) = last_from.write() {
+                                *lf = Some(env.from.clone());
+                            }
+                            if let Ok(mut li) = last_intent.write() {
+                                *li = Some(env.intent.get_name().to_string_box().value);
+                            }
+                            // 最小インタープリタで FunctionBox を実行
+                            let mut interp = crate::interpreter::NyashInterpreter::new();
+                            // キャプチャ注入
+                            for (k, v) in func_clone.env.captures.iter() {
+                                interp.declare_local_variable(k, v.clone_or_share());
+                            }
+                            if let Some(me_w) = &func_clone.env.me_value {
+                                if let Some(me_arc) = me_w.upgrade() {
+                                    interp.declare_local_variable("me", (*me_arc).clone_or_share());
+                                }
+                            }
+                            // 引数束縛: intent, from（必要数だけ）
+                            let args: Vec<Box<dyn NyashBox>> = vec![
+                                Box::new(env.intent.clone()),
+                                Box::new(StringBox::new(env.from.clone())),
+                            ];
+                            for (i, p) in func_clone.params.iter().enumerate() {
+                                if let Some(av) = args.get(i) {
+                                    interp.declare_local_variable(p, av.clone_or_share());
+                                }
+                            }
+                            // 本体実行
+                            crate::runtime::global_hooks::push_task_scope();
+                            for st in &func_clone.body {
+                                let _ = interp.execute_statement(st);
+                            }
+                            crate::runtime::global_hooks::pop_task_scope();
+                            if once {
+                                flag.store(false, Ordering::SeqCst);
+                                if let Ok(mut flags) = flags_arc.write() {
+                                    if let Some(v) = flags.get_mut(&intent_name_closure) {
+                                        v.clear();
+                                    }
+                                }
                             }
                         }
-                        // 引数束縛: intent, from（必要数だけ）
-                        let args: Vec<Box<dyn NyashBox>> = vec![
-                            Box::new(env.intent.clone()),
-                            Box::new(StringBox::new(env.from.clone())),
-                        ];
-                        for (i, p) in func_clone.params.iter().enumerate() {
-                            if let Some(av) = args.get(i) {
-                                interp.declare_local_variable(p, av.clone_or_share());
-                            }
-                        }
-                        // 本体実行
-                        crate::runtime::global_hooks::push_task_scope();
-                        for st in &func_clone.body {
-                            let _ = interp.execute_statement(st);
-                        }
-                        crate::runtime::global_hooks::pop_task_scope();
-                        if once {
-                            flag.store(false, Ordering::SeqCst);
-                            if let Ok(mut flags) = flags_arc.write() {
-                                if let Some(v) = flags.get_mut(&intent_name_closure) { v.clear(); }
-                            }
-                        }
-                    }
-                }));
+                    }),
+                );
             }
         }
         Box::new(ResultBox::new_ok(Box::new(BoolBox::new(true))))
     }
 
     /// イベントハンドラーを登録
-    pub fn on(&self, intent_name: Box<dyn NyashBox>, handler: Box<dyn NyashBox>) -> Box<dyn NyashBox> {
+    pub fn on(
+        &self,
+        intent_name: Box<dyn NyashBox>,
+        handler: Box<dyn NyashBox>,
+    ) -> Box<dyn NyashBox> {
         let intent_str = intent_name.to_string_box().value;
         self.register_handler_internal(&intent_str, &handler, false)
     }
 
     /// 一度だけのハンドラー登録
-    pub fn on_once(&self, intent_name: Box<dyn NyashBox>, handler: Box<dyn NyashBox>) -> Box<dyn NyashBox> {
+    pub fn on_once(
+        &self,
+        intent_name: Box<dyn NyashBox>,
+        handler: Box<dyn NyashBox>,
+    ) -> Box<dyn NyashBox> {
         let intent_str = intent_name.to_string_box().value;
         self.register_handler_internal(&intent_str, &handler, true)
     }
@@ -350,7 +411,9 @@ impl P2PBox {
         let intent_str = intent_name.to_string_box().value;
         if let Ok(mut flags) = self.handler_flags.write() {
             if let Some(v) = flags.get_mut(&intent_str) {
-                for f in v.iter() { f.store(false, Ordering::SeqCst); }
+                for f in v.iter() {
+                    f.store(false, Ordering::SeqCst);
+                }
                 v.clear();
             }
         }
@@ -364,7 +427,7 @@ impl P2PBox {
         let transport = self.transport.read().unwrap();
         Box::new(BoolBox::new(transport.is_reachable(&node_str)))
     }
-    
+
     /// トランスポート種類を取得
     pub fn get_transport_type(&self) -> Box<dyn NyashBox> {
         let transport = self.transport.read().unwrap();
@@ -396,11 +459,16 @@ impl P2PBox {
         // once登録かつ直近受信が同名なら 0 を返す（自己送信の安定化用）
         if let (Ok(once_map), Ok(last)) = (self.handler_once.read(), self.last_intent_name.read()) {
             if let Some(true) = once_map.get(&name).copied() {
-                if let Some(li) = &*last { if li == &name { return Box::new(crate::box_trait::IntegerBox::new(0)); } }
+                if let Some(li) = &*last {
+                    if li == &name {
+                        return Box::new(crate::box_trait::IntegerBox::new(0));
+                    }
+                }
             }
         }
         let flags = self.handler_flags.read().unwrap();
-        let cnt = flags.get(&name)
+        let cnt = flags
+            .get(&name)
             .map(|v| v.iter().filter(|f| f.load(Ordering::SeqCst)).count())
             .unwrap_or(0);
         Box::new(crate::box_trait::IntegerBox::new(cnt as i64))
@@ -414,18 +482,21 @@ impl P2PBox {
 
     /// 最後に受信したIntent名を取得（ループバック検証用）
     pub fn get_last_intent_name(&self) -> Box<dyn NyashBox> {
-        let v = self.last_intent_name.read().unwrap().clone().unwrap_or_default();
+        let v = self
+            .last_intent_name
+            .read()
+            .unwrap()
+            .clone()
+            .unwrap_or_default();
         Box::new(StringBox::new(v))
     }
 }
-
-
 
 impl NyashBox for P2PBox {
     fn clone_box(&self) -> Box<dyn NyashBox> {
         Box::new(self.clone())
     }
-    
+
     fn share_box(&self) -> Box<dyn NyashBox> {
         // Share underlying transport and state via Arc clones
         let node_id_val = self.node_id.read().unwrap().clone();
@@ -446,7 +517,7 @@ impl NyashBox for P2PBox {
         let transport_type = self.transport.read().unwrap().transport_type().to_string();
         StringBox::new(format!("P2PBox[{}:{}]", node_id, transport_type))
     }
-    
+
     fn equals(&self, other: &dyn NyashBox) -> BoolBox {
         if let Some(other_p2p) = other.as_any().downcast_ref::<P2PBox>() {
             BoolBox::new(self.base.id == other_p2p.base.id)
@@ -464,7 +535,7 @@ impl BoxCore for P2PBox {
     fn box_id(&self) -> u64 {
         self.base.id
     }
-    
+
     fn parent_type_id(&self) -> Option<std::any::TypeId> {
         self.base.parent_type_id
     }
@@ -474,11 +545,11 @@ impl BoxCore for P2PBox {
         let transport_type = self.transport.read().unwrap().transport_type().to_string();
         write!(f, "P2PBox[{}:{}]", node_id, transport_type)
     }
-    
+
     fn as_any(&self) -> &dyn Any {
         self
     }
-    
+
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
@@ -498,7 +569,10 @@ mod tests {
     fn self_ping_sets_last_fields() {
         let p = P2PBox::new("alice".to_string(), TransportKind::InProcess);
         let intent = IntentBox::new("ping".to_string(), serde_json::json!({}));
-        let res = p.send(Box::new(StringBox::new("alice".to_string())), Box::new(intent));
+        let res = p.send(
+            Box::new(StringBox::new("alice".to_string())),
+            Box::new(intent),
+        );
         // Ensure Ok
         if let Some(r) = res.as_any().downcast_ref::<ResultBox>() {
             assert!(matches!(r, ResultBox::Ok(_)));
@@ -506,7 +580,10 @@ mod tests {
             panic!("send did not return ResultBox");
         }
         assert_eq!(p.get_last_from().to_string_box().value, "alice".to_string());
-        assert_eq!(p.get_last_intent_name().to_string_box().value, "ping".to_string());
+        assert_eq!(
+            p.get_last_intent_name().to_string_box().value,
+            "ping".to_string()
+        );
     }
 
     /// Internal helper for tests: register raw Rust handler with optional async reply
@@ -521,22 +598,29 @@ mod tests {
                 // Avoid deep clone (which re-registers transport). Use transport directly for reply.
                 let transport_arc = Arc::clone(&self.transport);
                 let reply_name = reply_intent.map(|s| s.to_string());
-                t.register_intent_handler(&intent_name, Box::new(move |env| {
-                    if let Ok(mut lf) = last_from.write() { *lf = Some(env.from.clone()); }
-                    if let Ok(mut li) = last_intent.write() { *li = Some(env.intent.get_name().to_string_box().value); }
-                    if let Some(rn) = reply_name.clone() {
-                        let to = env.from.clone();
-                        let transport_arc = Arc::clone(&transport_arc);
-                        std::thread::spawn(move || {
-                            // slight delay to avoid lock contention
-                            std::thread::sleep(std::time::Duration::from_millis(5));
-                            let intent = IntentBox::new(rn, serde_json::json!({}));
-                            if let Ok(transport) = transport_arc.read() {
-                                let _ = transport.send(&to, intent, Default::default());
-                            }
-                        });
-                    }
-                }));
+                t.register_intent_handler(
+                    &intent_name,
+                    Box::new(move |env| {
+                        if let Ok(mut lf) = last_from.write() {
+                            *lf = Some(env.from.clone());
+                        }
+                        if let Ok(mut li) = last_intent.write() {
+                            *li = Some(env.intent.get_name().to_string_box().value);
+                        }
+                        if let Some(rn) = reply_name.clone() {
+                            let to = env.from.clone();
+                            let transport_arc = Arc::clone(&transport_arc);
+                            std::thread::spawn(move || {
+                                // slight delay to avoid lock contention
+                                std::thread::sleep(std::time::Duration::from_millis(5));
+                                let intent = IntentBox::new(rn, serde_json::json!({}));
+                                if let Ok(transport) = transport_arc.read() {
+                                    let _ = transport.send(&to, intent, Default::default());
+                                }
+                            });
+                        }
+                    }),
+                );
             }
         }
     }

--- a/src/jit/engine.rs
+++ b/src/jit/engine.rs
@@ -12,9 +12,15 @@ pub struct JitEngine {
     initialized: bool,
     next_handle: u64,
     /// Stub function table: handle -> callable closure
-    fntab: HashMap<u64, Arc<dyn Fn(&[crate::jit::abi::JitValue]) -> crate::jit::abi::JitValue + Send + Sync>>,
+    fntab: HashMap<
+        u64,
+        Arc<dyn Fn(&[crate::jit::abi::JitValue]) -> crate::jit::abi::JitValue + Send + Sync>,
+    >,
     /// Host externs by symbol name (Phase 10_d)
-    externs: HashMap<String, Arc<dyn Fn(&[crate::backend::vm::VMValue]) -> crate::backend::vm::VMValue + Send + Sync>>,
+    externs: HashMap<
+        String,
+        Arc<dyn Fn(&[crate::backend::vm::VMValue]) -> crate::backend::vm::VMValue + Send + Sync>,
+    >,
     #[cfg(feature = "cranelift-jit")]
     isa: Option<cranelift_codegen::isa::OwnedTargetIsa>,
     // Last lower stats (per function)
@@ -30,19 +36,26 @@ impl JitEngine {
             next_handle: 1,
             fntab: HashMap::new(),
             externs: HashMap::new(),
-            #[cfg(feature = "cranelift-jit")] isa: None,
+            #[cfg(feature = "cranelift-jit")]
+            isa: None,
             last_phi_total: 0,
             last_phi_b1: 0,
             last_ret_bool_hint: false,
         };
         #[cfg(feature = "cranelift-jit")]
-        { this.isa = None; }
+        {
+            this.isa = None;
+        }
         this.register_default_externs();
         this
     }
 
     /// Compile a function if supported; returns an opaque handle id
-    pub fn compile_function(&mut self, func_name: &str, mir: &crate::mir::MirFunction) -> Option<u64> {
+    pub fn compile_function(
+        &mut self,
+        func_name: &str,
+        mir: &crate::mir::MirFunction,
+    ) -> Option<u64> {
         let t0 = std::time::Instant::now();
         // Phase 10_b skeleton: walk MIR with LowerCore and report coverage
         // Reset compile-phase counters (e.g., fallback decisions) before lowering this function
@@ -59,17 +72,25 @@ impl JitEngine {
         // Strict: fail compile if any fallback decisions were taken during lowering
         let lower_fallbacks = crate::jit::events::lower_fallbacks_get();
         if lower_fallbacks > 0 && std::env::var("NYASH_JIT_STRICT").ok().as_deref() == Some("1") {
-            eprintln!("[JIT][strict] lower produced fallback decisions for {}: {} — failing compile", func_name, lower_fallbacks);
+            eprintln!(
+                "[JIT][strict] lower produced fallback decisions for {}: {} — failing compile",
+                func_name, lower_fallbacks
+            );
             return None;
         }
         // Capture per-function lower stats for manager to query later
         let (phi_t, phi_b1, ret_b) = lower.last_stats();
-        self.last_phi_total = phi_t; self.last_phi_b1 = phi_b1; self.last_ret_bool_hint = ret_b;
+        self.last_phi_total = phi_t;
+        self.last_phi_b1 = phi_b1;
+        self.last_ret_bool_hint = ret_b;
         // Record per-function stats into manager via callback if available (handled by caller)
         let cfg_now = crate::jit::config::current();
         // Strict mode: any unsupported lowering must fail-fast
         if lower.unsupported > 0 && std::env::var("NYASH_JIT_STRICT").ok().as_deref() == Some("1") {
-            eprintln!("[JIT][strict] unsupported lowering ops for {}: {} — failing compile", func_name, lower.unsupported);
+            eprintln!(
+                "[JIT][strict] unsupported lowering ops for {}: {} — failing compile",
+                func_name, lower.unsupported
+            );
             return None;
         }
         if cfg_now.dump {
@@ -104,13 +125,19 @@ impl JitEngine {
         }
         // If lowering left any unsupported instructions, do not register a closure.
         // This preserves VM semantics until coverage is complete for the function.
-        if lower.unsupported > 0 && std::env::var("NYASH_AOT_ALLOW_UNSUPPORTED").ok().as_deref() != Some("1") {
+        if lower.unsupported > 0
+            && std::env::var("NYASH_AOT_ALLOW_UNSUPPORTED").ok().as_deref() != Some("1")
+        {
             if std::env::var("NYASH_JIT_STATS").ok().as_deref() == Some("1") || cfg_now.dump {
-                eprintln!("[JIT] skip compile for {}: unsupported={} (>0)", func_name, lower.unsupported);
+                eprintln!(
+                    "[JIT] skip compile for {}: unsupported={} (>0)",
+                    func_name, lower.unsupported
+                );
             }
             return None;
         }
         // If AOT object emission is requested, emit object directly without JIT builder to avoid signature/linkage differences.
+        #[cfg(feature = "cranelift-jit")]
         if let Ok(path) = std::env::var("NYASH_AOT_OBJECT_OUT") {
             if !path.is_empty() {
                 let mut lower2 = crate::jit::lower::core::LowerCore::new();
@@ -121,11 +148,21 @@ impl JitEngine {
                         if let Some(bytes) = objb.take_object_bytes() {
                             use std::path::Path;
                             let p = Path::new(&path);
-                            let out_path = if p.is_dir() || path.ends_with('/') { p.join(format!("{}.o", func_name)) } else { p.to_path_buf() };
-                            if let Some(parent) = out_path.parent() { let _ = std::fs::create_dir_all(parent); }
+                            let out_path = if p.is_dir() || path.ends_with('/') {
+                                p.join(format!("{}.o", func_name))
+                            } else {
+                                p.to_path_buf()
+                            };
+                            if let Some(parent) = out_path.parent() {
+                                let _ = std::fs::create_dir_all(parent);
+                            }
                             match std::fs::write(&out_path, bytes) {
                                 Ok(_) => eprintln!("[AOT] wrote object: {}", out_path.display()),
-                                Err(e) => eprintln!("[AOT] failed to write object {}: {}", out_path.display(), e),
+                                Err(e) => eprintln!(
+                                    "[AOT] failed to write object {}: {}",
+                                    out_path.display(),
+                                    e
+                                ),
                             }
                         } else {
                             eprintln!("[AOT] no object bytes available for {}", func_name);
@@ -156,13 +193,25 @@ impl JitEngine {
                         } else if let Some(bytes) = objb.take_object_bytes() {
                             use std::path::Path;
                             let p = Path::new(&path);
-                            let out_path = if p.is_dir() || path.ends_with('/') { p.join(format!("{}.o", func_name)) } else { p.to_path_buf() };
-                            if let Some(parent) = out_path.parent() { let _ = std::fs::create_dir_all(parent); }
+                            let out_path = if p.is_dir() || path.ends_with('/') {
+                                p.join(format!("{}.o", func_name))
+                            } else {
+                                p.to_path_buf()
+                            };
+                            if let Some(parent) = out_path.parent() {
+                                let _ = std::fs::create_dir_all(parent);
+                            }
                             match std::fs::write(&out_path, bytes) {
                                 Ok(_) => {
                                     eprintln!("[AOT] wrote object: {}", out_path.display());
                                 }
-                                Err(e) => { eprintln!("[AOT] failed to write object {}: {}", out_path.display(), e); }
+                                Err(e) => {
+                                    eprintln!(
+                                        "[AOT] failed to write object {}: {}",
+                                        out_path.display(),
+                                        e
+                                    );
+                                }
                             }
                         }
                     }
@@ -181,11 +230,23 @@ impl JitEngine {
                             if let Some(bytes) = objb.take_object_bytes() {
                                 use std::path::Path;
                                 let p = Path::new(&path);
-                                let out_path = if p.is_dir() || path.ends_with('/') { p.join(format!("{}.o", func_name)) } else { p.to_path_buf() };
-                                if let Some(parent) = out_path.parent() { let _ = std::fs::create_dir_all(parent); }
+                                let out_path = if p.is_dir() || path.ends_with('/') {
+                                    p.join(format!("{}.o", func_name))
+                                } else {
+                                    p.to_path_buf()
+                                };
+                                if let Some(parent) = out_path.parent() {
+                                    let _ = std::fs::create_dir_all(parent);
+                                }
                                 match std::fs::write(&out_path, bytes) {
-                                    Ok(_) => eprintln!("[AOT] wrote object: {}", out_path.display()),
-                                    Err(e) => eprintln!("[AOT] failed to write object {}: {}", out_path.display(), e),
+                                    Ok(_) => {
+                                        eprintln!("[AOT] wrote object: {}", out_path.display())
+                                    }
+                                    Err(e) => eprintln!(
+                                        "[AOT] failed to write object {}: {}",
+                                        out_path.display(),
+                                        e
+                                    ),
                                 }
                             } else {
                                 eprintln!("[AOT] no object bytes available for {}", func_name);
@@ -202,26 +263,47 @@ impl JitEngine {
             // Report as not compiled so VM path remains authoritative.
             if std::env::var("NYASH_JIT_STATS").ok().as_deref() == Some("1") {
                 let dt = t0.elapsed();
-                eprintln!("[JIT] compile skipped (no cranelift) for {} after {}ms", func_name, dt.as_millis());
+                eprintln!(
+                    "[JIT] compile skipped (no cranelift) for {} after {}ms",
+                    func_name,
+                    dt.as_millis()
+                );
             }
             return None;
         }
     }
 
     /// Get statistics from the last lowered function
-    pub fn last_lower_stats(&self) -> (u64, u64, bool) { (self.last_phi_total, self.last_phi_b1, self.last_ret_bool_hint) }
+    pub fn last_lower_stats(&self) -> (u64, u64, bool) {
+        (
+            self.last_phi_total,
+            self.last_phi_b1,
+            self.last_ret_bool_hint,
+        )
+    }
 
     /// Execute compiled function by handle with trap fallback.
     /// Returns Some(VMValue) if executed successfully; None on missing handle or trap (panic).
-    pub fn execute_handle(&self, handle: u64, args: &[crate::jit::abi::JitValue]) -> Option<crate::jit::abi::JitValue> {
-        let f = match self.fntab.get(&handle) { Some(f) => f, None => return None };
+    pub fn execute_handle(
+        &self,
+        handle: u64,
+        args: &[crate::jit::abi::JitValue],
+    ) -> Option<crate::jit::abi::JitValue> {
+        let f = match self.fntab.get(&handle) {
+            Some(f) => f,
+            None => return None,
+        };
         let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| (f)(args)));
         match res {
             Ok(v) => Some(v),
             Err(_) => {
-                if std::env::var("NYASH_JIT_STATS").ok().as_deref() == Some("1") ||
-                   std::env::var("NYASH_JIT_TRAP_LOG").ok().as_deref() == Some("1") {
-                    eprintln!("[JIT] trap: panic during handle={} execution — falling back to VM", handle);
+                if std::env::var("NYASH_JIT_STATS").ok().as_deref() == Some("1")
+                    || std::env::var("NYASH_JIT_TRAP_LOG").ok().as_deref() == Some("1")
+                {
+                    eprintln!(
+                        "[JIT] trap: panic during handle={} execution — falling back to VM",
+                        handle
+                    );
                 }
                 None
             }
@@ -248,21 +330,48 @@ impl JitEngine {
             self.register_extern(hb::SYM_HOST_MAP_GET, Arc::new(|args| hb::map_get(args)));
             self.register_extern(hb::SYM_HOST_MAP_SET, Arc::new(|args| hb::map_set(args)));
             self.register_extern(hb::SYM_HOST_MAP_HAS, Arc::new(|args| hb::map_has(args)));
-            self.register_extern(hb::SYM_HOST_CONSOLE_LOG, Arc::new(|args| hb::console_log(args)));
-            self.register_extern(hb::SYM_HOST_CONSOLE_WARN, Arc::new(|args| hb::console_warn(args)));
-            self.register_extern(hb::SYM_HOST_CONSOLE_ERROR, Arc::new(|args| hb::console_error(args)));
-            self.register_extern(hb::SYM_HOST_INSTANCE_GETFIELD, Arc::new(|args| hb::instance_getfield(args)));
-            self.register_extern(hb::SYM_HOST_INSTANCE_SETFIELD, Arc::new(|args| hb::instance_setfield(args)));
-            self.register_extern(hb::SYM_HOST_STRING_LEN, Arc::new(|args| hb::string_len(args)));
+            self.register_extern(
+                hb::SYM_HOST_CONSOLE_LOG,
+                Arc::new(|args| hb::console_log(args)),
+            );
+            self.register_extern(
+                hb::SYM_HOST_CONSOLE_WARN,
+                Arc::new(|args| hb::console_warn(args)),
+            );
+            self.register_extern(
+                hb::SYM_HOST_CONSOLE_ERROR,
+                Arc::new(|args| hb::console_error(args)),
+            );
+            self.register_extern(
+                hb::SYM_HOST_INSTANCE_GETFIELD,
+                Arc::new(|args| hb::instance_getfield(args)),
+            );
+            self.register_extern(
+                hb::SYM_HOST_INSTANCE_SETFIELD,
+                Arc::new(|args| hb::instance_setfield(args)),
+            );
+            self.register_extern(
+                hb::SYM_HOST_STRING_LEN,
+                Arc::new(|args| hb::string_len(args)),
+            );
         }
     }
 
-    pub fn register_extern(&mut self, name: &str, f: Arc<dyn Fn(&[crate::backend::vm::VMValue]) -> crate::backend::vm::VMValue + Send + Sync>) {
+    pub fn register_extern(
+        &mut self,
+        name: &str,
+        f: Arc<dyn Fn(&[crate::backend::vm::VMValue]) -> crate::backend::vm::VMValue + Send + Sync>,
+    ) {
         self.externs.insert(name.to_string(), f);
     }
 
     /// Lookup an extern symbol (to be used by the lowering once call emission is added)
-    pub fn lookup_extern(&self, name: &str) -> Option<Arc<dyn Fn(&[crate::backend::vm::VMValue]) -> crate::backend::vm::VMValue + Send + Sync>> {
+    pub fn lookup_extern(
+        &self,
+        name: &str,
+    ) -> Option<
+        Arc<dyn Fn(&[crate::backend::vm::VMValue]) -> crate::backend::vm::VMValue + Send + Sync>,
+    > {
         self.externs.get(name).cloned()
     }
 }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1,20 +1,22 @@
 /*!
  * Nyash Parser - Expression Parsing Module
- * 
+ *
  * 式（Expression）の解析を担当するモジュール
  * 演算子の優先順位に従った再帰下降パーサー実装
  */
 
-use crate::tokenizer::TokenType;
-use crate::ast::{ASTNode, BinaryOperator, LiteralValue, UnaryOperator, Span};
-use super::{NyashParser, ParseError};
 use super::common::ParserUtils;
+use super::{NyashParser, ParseError};
+use crate::ast::{ASTNode, BinaryOperator, LiteralValue, Span, UnaryOperator};
+use crate::tokenizer::TokenType;
 
 // Debug macros are now imported from the parent module via #[macro_export]
 use crate::must_advance;
 
 #[inline]
-fn is_sugar_enabled() -> bool { crate::parser::sugar_gate::is_enabled() }
+fn is_sugar_enabled() -> bool {
+    crate::parser::sugar_gate::is_enabled()
+}
 
 impl NyashParser {
     /// 式をパース (演算子優先順位あり)
@@ -27,7 +29,7 @@ impl NyashParser {
     fn parse_pipeline(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_coalesce()?;
 
-        while self.match_token(&TokenType::PIPE_FORWARD) {
+        while self.match_token(&TokenType::PipeForward) {
             if !is_sugar_enabled() {
                 let line = self.current_token().line;
                 return Err(ParseError::UnexpectedToken {
@@ -44,29 +46,60 @@ impl NyashParser {
 
             // 変換: rhs の形に応じて lhs を先頭引数として追加
             expr = match rhs {
-                ASTNode::FunctionCall { name, mut arguments, span } => {
+                ASTNode::FunctionCall {
+                    name,
+                    mut arguments,
+                    span,
+                } => {
                     let mut new_args = Vec::with_capacity(arguments.len() + 1);
                     new_args.push(expr);
                     new_args.append(&mut arguments);
-                    ASTNode::FunctionCall { name, arguments: new_args, span }
+                    ASTNode::FunctionCall {
+                        name,
+                        arguments: new_args,
+                        span,
+                    }
                 }
-                ASTNode::MethodCall { object, method, mut arguments, span } => {
+                ASTNode::MethodCall {
+                    object,
+                    method,
+                    mut arguments,
+                    span,
+                } => {
                     let mut new_args = Vec::with_capacity(arguments.len() + 1);
                     new_args.push(expr);
                     new_args.append(&mut arguments);
-                    ASTNode::MethodCall { object, method, arguments: new_args, span }
+                    ASTNode::MethodCall {
+                        object,
+                        method,
+                        arguments: new_args,
+                        span,
+                    }
                 }
-                ASTNode::Variable { name, .. } => {
-                    ASTNode::FunctionCall { name, arguments: vec![expr], span: Span::unknown() }
-                }
-                ASTNode::FieldAccess { object, field, .. } => {
-                    ASTNode::MethodCall { object, method: field, arguments: vec![expr], span: Span::unknown() }
-                }
-                ASTNode::Call { callee, mut arguments, span } => {
+                ASTNode::Variable { name, .. } => ASTNode::FunctionCall {
+                    name,
+                    arguments: vec![expr],
+                    span: Span::unknown(),
+                },
+                ASTNode::FieldAccess { object, field, .. } => ASTNode::MethodCall {
+                    object,
+                    method: field,
+                    arguments: vec![expr],
+                    span: Span::unknown(),
+                },
+                ASTNode::Call {
+                    callee,
+                    mut arguments,
+                    span,
+                } => {
                     let mut new_args = Vec::with_capacity(arguments.len() + 1);
                     new_args.push(expr);
                     new_args.append(&mut arguments);
-                    ASTNode::Call { callee, arguments: new_args, span }
+                    ASTNode::Call {
+                        callee,
+                        arguments: new_args,
+                        span,
+                    }
                 }
                 other => {
                     // 許容外: 関数/メソッド/変数/フィールド以外には適用不可
@@ -85,7 +118,7 @@ impl NyashParser {
     /// デフォルト値（??）: x ?? y => peek x { null => y, else => x }
     fn parse_coalesce(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_or()?;
-        while self.match_token(&TokenType::QMARK_QMARK) {
+        while self.match_token(&TokenType::QmarkQmark) {
             if !is_sugar_enabled() {
                 let line = self.current_token().line;
                 return Err(ParseError::UnexpectedToken {
@@ -106,11 +139,11 @@ impl NyashParser {
         }
         Ok(expr)
     }
-    
+
     /// OR演算子をパース: ||
     fn parse_or(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_and()?;
-        
+
         while self.match_token(&TokenType::OR) {
             let operator = BinaryOperator::Or;
             self.advance();
@@ -118,7 +151,9 @@ impl NyashParser {
             // Non-invasive syntax diff: record binop
             if std::env::var("NYASH_GRAMMAR_DIFF").ok().as_deref() == Some("1") {
                 let ok = crate::grammar::engine::get().syntax_is_allowed_binop("or");
-                if !ok { eprintln!("[GRAMMAR-DIFF][Parser] binop 'or' not allowed by syntax rules"); }
+                if !ok {
+                    eprintln!("[GRAMMAR-DIFF][Parser] binop 'or' not allowed by syntax rules");
+                }
             }
             expr = ASTNode::BinaryOp {
                 operator,
@@ -127,21 +162,23 @@ impl NyashParser {
                 span: Span::unknown(),
             };
         }
-        
+
         Ok(expr)
     }
-    
+
     /// AND演算子をパース: &&
     fn parse_and(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_equality()?;
-        
+
         while self.match_token(&TokenType::AND) {
             let operator = BinaryOperator::And;
             self.advance();
             let right = self.parse_equality()?;
             if std::env::var("NYASH_GRAMMAR_DIFF").ok().as_deref() == Some("1") {
                 let ok = crate::grammar::engine::get().syntax_is_allowed_binop("and");
-                if !ok { eprintln!("[GRAMMAR-DIFF][Parser] binop 'and' not allowed by syntax rules"); }
+                if !ok {
+                    eprintln!("[GRAMMAR-DIFF][Parser] binop 'and' not allowed by syntax rules");
+                }
             }
             expr = ASTNode::BinaryOp {
                 operator,
@@ -150,14 +187,14 @@ impl NyashParser {
                 span: Span::unknown(),
             };
         }
-        
+
         Ok(expr)
     }
-    
+
     /// 等値演算子をパース: == !=
     fn parse_equality(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_comparison()?;
-        
+
         while self.match_token(&TokenType::EQUALS) || self.match_token(&TokenType::NotEquals) {
             let operator = match &self.current_token().token_type {
                 TokenType::EQUALS => BinaryOperator::Equal,
@@ -167,9 +204,18 @@ impl NyashParser {
             self.advance();
             let right = self.parse_comparison()?;
             if std::env::var("NYASH_GRAMMAR_DIFF").ok().as_deref() == Some("1") {
-                let name = match operator { BinaryOperator::Equal=>"eq", BinaryOperator::NotEqual=>"ne", _=>"cmp" };
+                let name = match operator {
+                    BinaryOperator::Equal => "eq",
+                    BinaryOperator::NotEqual => "ne",
+                    _ => "cmp",
+                };
                 let ok = crate::grammar::engine::get().syntax_is_allowed_binop(name);
-                if !ok { eprintln!("[GRAMMAR-DIFF][Parser] binop '{}' not allowed by syntax rules", name); }
+                if !ok {
+                    eprintln!(
+                        "[GRAMMAR-DIFF][Parser] binop '{}' not allowed by syntax rules",
+                        name
+                    );
+                }
             }
             expr = ASTNode::BinaryOp {
                 operator,
@@ -178,18 +224,19 @@ impl NyashParser {
                 span: Span::unknown(),
             };
         }
-        
+
         Ok(expr)
     }
-    
+
     /// 比較演算子をパース: < <= > >=
     fn parse_comparison(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_range()?;
-        
-        while self.match_token(&TokenType::LESS) || 
-              self.match_token(&TokenType::LessEquals) ||
-              self.match_token(&TokenType::GREATER) ||
-              self.match_token(&TokenType::GreaterEquals) {
+
+        while self.match_token(&TokenType::LESS)
+            || self.match_token(&TokenType::LessEquals)
+            || self.match_token(&TokenType::GREATER)
+            || self.match_token(&TokenType::GreaterEquals)
+        {
             let operator = match &self.current_token().token_type {
                 TokenType::LESS => BinaryOperator::Less,
                 TokenType::LessEquals => BinaryOperator::LessEqual,
@@ -206,7 +253,7 @@ impl NyashParser {
                 span: Span::unknown(),
             };
         }
-        
+
         Ok(expr)
     }
 
@@ -224,16 +271,23 @@ impl NyashParser {
             }
             self.advance(); // consume '..'
             let rhs = self.parse_term()?;
-            expr = ASTNode::FunctionCall { name: "Range".to_string(), arguments: vec![expr, rhs], span: Span::unknown() };
+            expr = ASTNode::FunctionCall {
+                name: "Range".to_string(),
+                arguments: vec![expr, rhs],
+                span: Span::unknown(),
+            };
         }
         Ok(expr)
     }
-    
+
     /// 項をパース: + - >>
     fn parse_term(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_factor()?;
-        
-        while self.match_token(&TokenType::PLUS) || self.match_token(&TokenType::MINUS) || self.match_token(&TokenType::ARROW) {
+
+        while self.match_token(&TokenType::PLUS)
+            || self.match_token(&TokenType::MINUS)
+            || self.match_token(&TokenType::ARROW)
+        {
             if self.match_token(&TokenType::ARROW) {
                 // >> Arrow演算子
                 self.advance();
@@ -252,9 +306,18 @@ impl NyashParser {
                 self.advance();
                 let right = self.parse_factor()?;
                 if std::env::var("NYASH_GRAMMAR_DIFF").ok().as_deref() == Some("1") {
-                    let name = match operator { BinaryOperator::Add=>"add", BinaryOperator::Subtract=>"sub", _=>"term" };
+                    let name = match operator {
+                        BinaryOperator::Add => "add",
+                        BinaryOperator::Subtract => "sub",
+                        _ => "term",
+                    };
                     let ok = crate::grammar::engine::get().syntax_is_allowed_binop(name);
-                    if !ok { eprintln!("[GRAMMAR-DIFF][Parser] binop '{}' not allowed by syntax rules", name); }
+                    if !ok {
+                        eprintln!(
+                            "[GRAMMAR-DIFF][Parser] binop '{}' not allowed by syntax rules",
+                            name
+                        );
+                    }
                 }
                 expr = ASTNode::BinaryOp {
                     operator,
@@ -264,15 +327,18 @@ impl NyashParser {
                 };
             }
         }
-        
+
         Ok(expr)
     }
-    
+
     /// 因子をパース: * /
     fn parse_factor(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_unary()?;
-        
-        while self.match_token(&TokenType::MULTIPLY) || self.match_token(&TokenType::DIVIDE) || self.match_token(&TokenType::MODULO) {
+
+        while self.match_token(&TokenType::MULTIPLY)
+            || self.match_token(&TokenType::DIVIDE)
+            || self.match_token(&TokenType::MODULO)
+        {
             let operator = match &self.current_token().token_type {
                 TokenType::MULTIPLY => BinaryOperator::Multiply,
                 TokenType::DIVIDE => BinaryOperator::Divide,
@@ -282,9 +348,18 @@ impl NyashParser {
             self.advance();
             let right = self.parse_unary()?;
             if std::env::var("NYASH_GRAMMAR_DIFF").ok().as_deref() == Some("1") {
-                let name = match operator { BinaryOperator::Multiply=>"mul", BinaryOperator::Divide=>"div", _=>"mod" };
+                let name = match operator {
+                    BinaryOperator::Multiply => "mul",
+                    BinaryOperator::Divide => "div",
+                    _ => "mod",
+                };
                 let ok = crate::grammar::engine::get().syntax_is_allowed_binop(name);
-                if !ok { eprintln!("[GRAMMAR-DIFF][Parser] binop '{}' not allowed by syntax rules", name); }
+                if !ok {
+                    eprintln!(
+                        "[GRAMMAR-DIFF][Parser] binop '{}' not allowed by syntax rules",
+                        name
+                    );
+                }
             }
             expr = ASTNode::BinaryOp {
                 operator,
@@ -293,10 +368,10 @@ impl NyashParser {
                 span: Span::unknown(),
             };
         }
-        
+
         Ok(expr)
     }
-    
+
     /// 単項演算子をパース
     fn parse_unary(&mut self) -> Result<ASTNode, ParseError> {
         // peek式の先読み
@@ -312,7 +387,7 @@ impl NyashParser {
                 span: Span::unknown(),
             });
         }
-        
+
         if self.match_token(&TokenType::NOT) {
             self.advance(); // consume 'not'
             let operand = self.parse_unary()?; // 再帰的に単項演算をパース
@@ -322,7 +397,7 @@ impl NyashParser {
                 span: Span::unknown(),
             });
         }
-        
+
         if self.match_token(&TokenType::AWAIT) {
             self.advance(); // consume 'await'
             let expression = self.parse_unary()?; // 再帰的にパース
@@ -331,7 +406,7 @@ impl NyashParser {
                 span: Span::unknown(),
             });
         }
-        
+
         self.parse_call()
     }
 
@@ -351,13 +426,15 @@ impl NyashParser {
                 self.advance();
                 self.skip_newlines();
             }
-            if self.match_token(&TokenType::RBRACE) { break; }
+            if self.match_token(&TokenType::RBRACE) {
+                break;
+            }
 
             // else or literal
             let is_else = matches!(self.current_token().token_type, TokenType::ELSE);
             if is_else {
                 self.advance(); // consume 'else'
-                self.consume(TokenType::FAT_ARROW)?;
+                self.consume(TokenType::FatArrow)?;
                 // else アーム: ブロック or 式
                 let expr = if self.match_token(&TokenType::LBRACE) {
                     // ブロックを式として扱う（最後の文の値が返る）
@@ -370,7 +447,10 @@ impl NyashParser {
                         }
                     }
                     self.consume(TokenType::RBRACE)?;
-                    ASTNode::Program { statements: stmts, span: Span::unknown() }
+                    ASTNode::Program {
+                        statements: stmts,
+                        span: Span::unknown(),
+                    }
                 } else {
                     self.parse_expression()?
                 };
@@ -378,7 +458,7 @@ impl NyashParser {
             } else {
                 // リテラルのみ許可（P0）
                 let lit = self.parse_literal_only()?;
-                self.consume(TokenType::FAT_ARROW)?;
+                self.consume(TokenType::FatArrow)?;
                 // アーム: ブロック or 式
                 let expr = if self.match_token(&TokenType::LBRACE) {
                     self.advance(); // consume '{'
@@ -390,7 +470,10 @@ impl NyashParser {
                         }
                     }
                     self.consume(TokenType::RBRACE)?;
-                    ASTNode::Program { statements: stmts, span: Span::unknown() }
+                    ASTNode::Program {
+                        statements: stmts,
+                        span: Span::unknown(),
+                    }
                 } else {
                     self.parse_expression()?
                 };
@@ -398,8 +481,12 @@ impl NyashParser {
             }
 
             // 区切り（カンマや改行を許可）
-            if self.match_token(&TokenType::COMMA) { self.advance(); }
-            if self.match_token(&TokenType::NEWLINE) { self.advance(); }
+            if self.match_token(&TokenType::COMMA) {
+                self.advance();
+            }
+            if self.match_token(&TokenType::NEWLINE) {
+                self.advance();
+            }
         }
 
         self.consume(TokenType::RBRACE)?;
@@ -419,51 +506,76 @@ impl NyashParser {
 
     fn parse_literal_only(&mut self) -> Result<crate::ast::LiteralValue, ParseError> {
         match &self.current_token().token_type {
-            TokenType::STRING(s) => { let v = crate::ast::LiteralValue::String(s.clone()); self.advance(); Ok(v) }
-            TokenType::NUMBER(n) => { let v = crate::ast::LiteralValue::Integer(*n); self.advance(); Ok(v) }
-            TokenType::FLOAT(f) => { let v = crate::ast::LiteralValue::Float(*f); self.advance(); Ok(v) }
-            TokenType::TRUE => { self.advance(); Ok(crate::ast::LiteralValue::Bool(true)) }
-            TokenType::FALSE => { self.advance(); Ok(crate::ast::LiteralValue::Bool(false)) }
-            TokenType::NULL => { self.advance(); Ok(crate::ast::LiteralValue::Null) }
+            TokenType::STRING(s) => {
+                let v = crate::ast::LiteralValue::String(s.clone());
+                self.advance();
+                Ok(v)
+            }
+            TokenType::NUMBER(n) => {
+                let v = crate::ast::LiteralValue::Integer(*n);
+                self.advance();
+                Ok(v)
+            }
+            TokenType::FLOAT(f) => {
+                let v = crate::ast::LiteralValue::Float(*f);
+                self.advance();
+                Ok(v)
+            }
+            TokenType::TRUE => {
+                self.advance();
+                Ok(crate::ast::LiteralValue::Bool(true))
+            }
+            TokenType::FALSE => {
+                self.advance();
+                Ok(crate::ast::LiteralValue::Bool(false))
+            }
+            TokenType::NULL => {
+                self.advance();
+                Ok(crate::ast::LiteralValue::Null)
+            }
             _ => {
                 let line = self.current_token().line;
-                Err(ParseError::UnexpectedToken { found: self.current_token().token_type.clone(), expected: "literal".to_string(), line })
+                Err(ParseError::UnexpectedToken {
+                    found: self.current_token().token_type.clone(),
+                    expected: "literal".to_string(),
+                    line,
+                })
             }
         }
     }
-    
+
     /// 関数・メソッド呼び出しをパース
     fn parse_call(&mut self) -> Result<ASTNode, ParseError> {
         let mut expr = self.parse_primary()?;
-        
+
         loop {
             if self.match_token(&TokenType::DOT) {
                 self.advance(); // consume '.'
-                
+
                 if let TokenType::IDENTIFIER(method_name) = &self.current_token().token_type {
                     let method_name = method_name.clone();
                     self.advance();
-                    
+
                     if self.match_token(&TokenType::LPAREN) {
                         // メソッド呼び出し: obj.method(args)
                         self.advance(); // consume '('
                         let mut arguments = Vec::new();
                         let mut _arg_count = 0;
-                        
+
                         while !self.match_token(&TokenType::RPAREN) && !self.is_at_end() {
                             must_advance!(self, _unused, "method call argument parsing");
-                            
+
                             arguments.push(self.parse_expression()?);
                             _arg_count += 1;
-                            
+
                             if self.match_token(&TokenType::COMMA) {
                                 self.advance();
                                 // カンマの後の trailing comma をチェック
                             }
                         }
-                        
+
                         self.consume(TokenType::RPAREN)?;
-                        
+
                         expr = ASTNode::MethodCall {
                             object: Box::new(expr),
                             method: method_name,
@@ -486,7 +598,7 @@ impl NyashParser {
                         line,
                     });
                 }
-            } else if self.match_token(&TokenType::QMARK_DOT) {
+            } else if self.match_token(&TokenType::QmarkDot) {
                 if !is_sugar_enabled() {
                     let line = self.current_token().line;
                     return Err(ParseError::UnexpectedToken {
@@ -496,12 +608,20 @@ impl NyashParser {
                     });
                 }
                 self.advance(); // consume '?.'
-                // ident then optional call
+                                // ident then optional call
                 let name = match &self.current_token().token_type {
-                    TokenType::IDENTIFIER(s) => { let v = s.clone(); self.advance(); v }
+                    TokenType::IDENTIFIER(s) => {
+                        let v = s.clone();
+                        self.advance();
+                        v
+                    }
                     _ => {
                         let line = self.current_token().line;
-                        return Err(ParseError::UnexpectedToken { found: self.current_token().token_type.clone(), expected: "identifier after '?.'".to_string(), line });
+                        return Err(ParseError::UnexpectedToken {
+                            found: self.current_token().token_type.clone(),
+                            expected: "identifier after '?.'".to_string(),
+                            line,
+                        });
                     }
                 };
                 let access = if self.match_token(&TokenType::LPAREN) {
@@ -511,23 +631,39 @@ impl NyashParser {
                     while !self.match_token(&TokenType::RPAREN) && !self.is_at_end() {
                         must_advance!(self, _unused, "safe method call arg parsing");
                         arguments.push(self.parse_expression()?);
-                        if self.match_token(&TokenType::COMMA) { self.advance(); }
+                        if self.match_token(&TokenType::COMMA) {
+                            self.advance();
+                        }
                     }
                     self.consume(TokenType::RPAREN)?;
-                    ASTNode::MethodCall { object: Box::new(expr.clone()), method: name, arguments, span: Span::unknown() }
+                    ASTNode::MethodCall {
+                        object: Box::new(expr.clone()),
+                        method: name,
+                        arguments,
+                        span: Span::unknown(),
+                    }
                 } else {
                     // field access
-                    ASTNode::FieldAccess { object: Box::new(expr.clone()), field: name, span: Span::unknown() }
+                    ASTNode::FieldAccess {
+                        object: Box::new(expr.clone()),
+                        field: name,
+                        span: Span::unknown(),
+                    }
                 };
 
                 // Wrap with peek: peek expr { null => null, else => access(expr) }
                 expr = ASTNode::PeekExpr {
                     scrutinee: Box::new(expr.clone()),
-                    arms: vec![(crate::ast::LiteralValue::Null, ASTNode::Literal { value: crate::ast::LiteralValue::Null, span: Span::unknown() })],
+                    arms: vec![(
+                        crate::ast::LiteralValue::Null,
+                        ASTNode::Literal {
+                            value: crate::ast::LiteralValue::Null,
+                            span: Span::unknown(),
+                        },
+                    )],
                     else_expr: Box::new(access),
                     span: Span::unknown(),
                 };
-
             } else if self.match_token(&TokenType::LPAREN) {
                 // 関数呼び出し: function(args) または 一般式呼び出し: (callee)(args)
                 self.advance(); // consume '('
@@ -535,27 +671,40 @@ impl NyashParser {
                 while !self.match_token(&TokenType::RPAREN) && !self.is_at_end() {
                     must_advance!(self, _unused, "function call argument parsing");
                     arguments.push(self.parse_expression()?);
-                    if self.match_token(&TokenType::COMMA) { self.advance(); }
+                    if self.match_token(&TokenType::COMMA) {
+                        self.advance();
+                    }
                 }
                 self.consume(TokenType::RPAREN)?;
 
                 if let ASTNode::Variable { name, .. } = expr.clone() {
-                    expr = ASTNode::FunctionCall { name, arguments, span: Span::unknown() };
+                    expr = ASTNode::FunctionCall {
+                        name,
+                        arguments,
+                        span: Span::unknown(),
+                    };
                 } else {
-                    expr = ASTNode::Call { callee: Box::new(expr), arguments, span: Span::unknown() };
+                    expr = ASTNode::Call {
+                        callee: Box::new(expr),
+                        arguments,
+                        span: Span::unknown(),
+                    };
                 }
             } else if self.match_token(&TokenType::QUESTION) {
                 // 後置 ?（Result伝播）
                 self.advance();
-                expr = ASTNode::QMarkPropagate { expression: Box::new(expr), span: Span::unknown() };
+                expr = ASTNode::QMarkPropagate {
+                    expression: Box::new(expr),
+                    span: Span::unknown(),
+                };
             } else {
                 break;
             }
         }
-        
+
         Ok(expr)
     }
-    
+
     /// 基本式をパース: リテラル、変数、括弧、this、new
     fn parse_primary(&mut self) -> Result<ASTNode, ParseError> {
         match &self.current_token().token_type {
@@ -567,31 +716,46 @@ impl NyashParser {
                 let value = s.clone();
                 self.advance();
                 // Use plain literal to keep primitives simple in interpreter/VM paths
-                Ok(ASTNode::Literal { value: LiteralValue::String(value), span: Span::unknown() })
+                Ok(ASTNode::Literal {
+                    value: LiteralValue::String(value),
+                    span: Span::unknown(),
+                })
             }
-            
+
             TokenType::NUMBER(n) => {
                 let value = *n;
                 self.advance();
-                Ok(ASTNode::Literal { value: LiteralValue::Integer(value), span: Span::unknown() })
+                Ok(ASTNode::Literal {
+                    value: LiteralValue::Integer(value),
+                    span: Span::unknown(),
+                })
             }
-            
+
             TokenType::FLOAT(f) => {
                 let value = *f;
                 self.advance();
-                Ok(ASTNode::Literal { value: LiteralValue::Float(value), span: Span::unknown() })
+                Ok(ASTNode::Literal {
+                    value: LiteralValue::Float(value),
+                    span: Span::unknown(),
+                })
             }
-            
+
             TokenType::TRUE => {
                 self.advance();
-                Ok(ASTNode::Literal { value: LiteralValue::Bool(true), span: Span::unknown() })
+                Ok(ASTNode::Literal {
+                    value: LiteralValue::Bool(true),
+                    span: Span::unknown(),
+                })
             }
-            
+
             TokenType::FALSE => {
                 self.advance();
-                Ok(ASTNode::Literal { value: LiteralValue::Bool(false), span: Span::unknown() })
+                Ok(ASTNode::Literal {
+                    value: LiteralValue::Bool(false),
+                    span: Span::unknown(),
+                })
             }
-            
+
             TokenType::NULL => {
                 self.advance();
                 Ok(ASTNode::Literal {
@@ -599,38 +763,47 @@ impl NyashParser {
                     span: Span::unknown(),
                 })
             }
-            
+
             TokenType::THIS => {
                 // Deprecation: normalize 'this' to 'me'
                 if std::env::var("NYASH_DEPRECATE_THIS").ok().as_deref() == Some("1") {
-                    eprintln!("[deprecate:this] 'this' is deprecated; use 'me' instead (line {})", self.current_token().line);
+                    eprintln!(
+                        "[deprecate:this] 'this' is deprecated; use 'me' instead (line {})",
+                        self.current_token().line
+                    );
                 }
                 self.advance();
-                Ok(ASTNode::Me { span: Span::unknown() })
+                Ok(ASTNode::Me {
+                    span: Span::unknown(),
+                })
             }
-            
+
             TokenType::ME => {
                 self.advance();
-                Ok(ASTNode::Me { span: Span::unknown() })
+                Ok(ASTNode::Me {
+                    span: Span::unknown(),
+                })
             }
-            
+
             TokenType::NEW => {
                 self.advance();
-                
+
                 if let TokenType::IDENTIFIER(class_name) = &self.current_token().token_type {
                     let class_name = class_name.clone();
                     self.advance();
-                    
+
                     // 🔥 ジェネリクス型引数のパース (<IntegerBox, StringBox>)
                     let type_arguments = if self.match_token(&TokenType::LESS) {
                         self.advance(); // consume '<'
                         let mut args = Vec::new();
-                        
+
                         loop {
-                            if let TokenType::IDENTIFIER(type_name) = &self.current_token().token_type {
+                            if let TokenType::IDENTIFIER(type_name) =
+                                &self.current_token().token_type
+                            {
                                 args.push(type_name.clone());
                                 self.advance();
-                                
+
                                 if self.match_token(&TokenType::COMMA) {
                                     self.advance(); // consume ','
                                 } else {
@@ -645,27 +818,27 @@ impl NyashParser {
                                 });
                             }
                         }
-                        
+
                         self.consume(TokenType::GREATER)?; // consume '>'
                         args
                     } else {
                         Vec::new()
                     };
-                    
+
                     self.consume(TokenType::LPAREN)?;
                     let mut arguments = Vec::new();
-                    
+
                     while !self.match_token(&TokenType::RPAREN) && !self.is_at_end() {
                         must_advance!(self, _unused, "new expression argument parsing");
-                        
+
                         arguments.push(self.parse_expression()?);
                         if self.match_token(&TokenType::COMMA) {
                             self.advance();
                         }
                     }
-                    
+
                     self.consume(TokenType::RPAREN)?;
-                    
+
                     Ok(ASTNode::New {
                         class: class_name,
                         arguments,
@@ -681,26 +854,43 @@ impl NyashParser {
                     })
                 }
             }
-            
+
             TokenType::FROM => {
                 // from構文をパース: from Parent.method(arguments)
                 self.parse_from_call()
             }
-            
+
             TokenType::IDENTIFIER(name) => {
                 let parent = name.clone();
                 self.advance();
-                if self.match_token(&TokenType::DOUBLE_COLON) {
+                if self.match_token(&TokenType::DoubleColon) {
                     // Parent::method(args)
                     self.advance(); // consume '::'
                     let method = match &self.current_token().token_type {
-                        TokenType::IDENTIFIER(m) => { let s=m.clone(); self.advance(); s }
-                        TokenType::INIT => { self.advance(); "init".to_string() }
-                        TokenType::PACK => { self.advance(); "pack".to_string() }
-                        TokenType::BIRTH => { self.advance(); "birth".to_string() }
+                        TokenType::IDENTIFIER(m) => {
+                            let s = m.clone();
+                            self.advance();
+                            s
+                        }
+                        TokenType::INIT => {
+                            self.advance();
+                            "init".to_string()
+                        }
+                        TokenType::PACK => {
+                            self.advance();
+                            "pack".to_string()
+                        }
+                        TokenType::BIRTH => {
+                            self.advance();
+                            "birth".to_string()
+                        }
                         _ => {
                             let line = self.current_token().line;
-                            return Err(ParseError::UnexpectedToken { found: self.current_token().token_type.clone(), expected: "method name".to_string(), line });
+                            return Err(ParseError::UnexpectedToken {
+                                found: self.current_token().token_type.clone(),
+                                expected: "method name".to_string(),
+                                line,
+                            });
                         }
                     };
                     self.consume(TokenType::LPAREN)?;
@@ -708,22 +898,32 @@ impl NyashParser {
                     while !self.match_token(&TokenType::RPAREN) && !self.is_at_end() {
                         must_advance!(self, _unused, "Parent::method call argument parsing");
                         arguments.push(self.parse_expression()?);
-                        if self.match_token(&TokenType::COMMA) { self.advance(); }
+                        if self.match_token(&TokenType::COMMA) {
+                            self.advance();
+                        }
                     }
                     self.consume(TokenType::RPAREN)?;
-                    Ok(ASTNode::FromCall { parent, method, arguments, span: Span::unknown() })
+                    Ok(ASTNode::FromCall {
+                        parent,
+                        method,
+                        arguments,
+                        span: Span::unknown(),
+                    })
                 } else {
-                    Ok(ASTNode::Variable { name: parent, span: Span::unknown() })
+                    Ok(ASTNode::Variable {
+                        name: parent,
+                        span: Span::unknown(),
+                    })
                 }
             }
-            
+
             TokenType::LPAREN => {
                 self.advance(); // consume '('
                 let expr = self.parse_expression()?;
                 self.consume(TokenType::RPAREN)?;
                 Ok(expr)
             }
-            
+
             TokenType::FN => {
                 // 無名関数: fn (params?) { body }
                 self.advance(); // consume 'fn'
@@ -734,10 +934,16 @@ impl NyashParser {
                         if let TokenType::IDENTIFIER(p) = &self.current_token().token_type {
                             params.push(p.clone());
                             self.advance();
-                            if self.match_token(&TokenType::COMMA) { self.advance(); }
+                            if self.match_token(&TokenType::COMMA) {
+                                self.advance();
+                            }
                         } else {
                             let line = self.current_token().line;
-                            return Err(ParseError::UnexpectedToken { found: self.current_token().token_type.clone(), expected: "parameter name".to_string(), line });
+                            return Err(ParseError::UnexpectedToken {
+                                found: self.current_token().token_type.clone(),
+                                expected: "parameter name".to_string(),
+                                line,
+                            });
                         }
                     }
                     self.consume(TokenType::RPAREN)?;
@@ -751,20 +957,24 @@ impl NyashParser {
                     }
                 }
                 self.consume(TokenType::RBRACE)?;
-                Ok(ASTNode::Lambda { params, body, span: Span::unknown() })
+                Ok(ASTNode::Lambda {
+                    params,
+                    body,
+                    span: Span::unknown(),
+                })
             }
-            
+
             _ => {
                 let line = self.current_token().line;
                 Err(ParseError::InvalidExpression { line })
             }
         }
     }
-    
+
     /// from構文をパース: from Parent.method(arguments)
     pub(super) fn parse_from_call(&mut self) -> Result<ASTNode, ParseError> {
         self.advance(); // consume 'from'
-        
+
         // Parent名を取得
         let parent = if let TokenType::IDENTIFIER(name) = &self.current_token().token_type {
             let name = name.clone();
@@ -778,12 +988,12 @@ impl NyashParser {
                 line,
             });
         };
-        
+
         // DOT とmethod名は任意（pack透明化対応）
         let method = if self.match_token(&TokenType::DOT) {
             // DOTがある場合: from Parent.method() 形式
             self.advance(); // consume DOT
-            
+
             // method名を取得 (IDENTIFIERまたはINITを受け入れ)
             match &self.current_token().token_type {
                 TokenType::IDENTIFIER(name) => {
@@ -817,28 +1027,31 @@ impl NyashParser {
             // Phase 8.9: 明示的birth()構文を強制
             let line = self.current_token().line;
             return Err(ParseError::TransparencySystemRemoved {
-                suggestion: format!("Use 'from {}.birth()' instead of 'from {}()'", parent, parent),
+                suggestion: format!(
+                    "Use 'from {}.birth()' instead of 'from {}()'",
+                    parent, parent
+                ),
                 line,
             });
         };
-        
+
         // 引数リストをパース
         self.consume(TokenType::LPAREN)?;
         let mut arguments = Vec::new();
-        
+
         while !self.match_token(&TokenType::RPAREN) && !self.is_at_end() {
             must_advance!(self, _unused, "from call argument parsing");
-            
+
             arguments.push(self.parse_expression()?);
-            
+
             if self.match_token(&TokenType::COMMA) {
                 self.advance();
                 // カンマの後の trailing comma をチェック
             }
         }
-        
+
         self.consume(TokenType::RPAREN)?;
-        
+
         Ok(ASTNode::FromCall {
             parent,
             method,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,16 +1,16 @@
 /*!
  * Nyash Parser - Rust Implementation
- * 
+ *
  * Python版nyashc_v4.pyのNyashParserをRustで完全再実装
  * Token列をAST (Abstract Syntax Tree) に変換
- * 
+ *
  * モジュール構造:
  * - common.rs: 共通ユーティリティとトレイト (ParserUtils)
  * - expressions.rs: 式パーサー (parse_expression, parse_or, parse_and等)
  * - statements.rs: 文パーサー (parse_statement, parse_if, parse_loop等)
  * - declarations/: Box宣言パーサー (box_definition, static_box, dependency_helpers)
  * - items/: トップレベル宣言 (global_vars, functions, static_items)
- * 
+ *
  * 2025-08-16: 大規模リファクタリング完了
  * - 1530行 → 227行 (85%削減)
  * - 機能ごとにモジュール分離で保守性向上
@@ -18,23 +18,25 @@
 
 // サブモジュール宣言
 mod common;
-mod expressions;
-mod statements;
 mod declarations;
-mod items;
-pub mod sugar; // Phase 12.7-B: desugar pass (basic)
 pub mod entry_sugar; // helper to parse with sugar level
+mod expressions;
+mod items;
+mod statements;
+pub mod sugar; // Phase 12.7-B: desugar pass (basic)
 pub mod sugar_gate; // thread-local gate for sugar parsing (tests/docs)
-// mod errors;
+                    // mod errors;
 
 use common::ParserUtils;
 
-use crate::tokenizer::{Token, TokenType, TokenizeError};
 use crate::ast::{ASTNode, Span};
+use crate::tokenizer::{Token, TokenType, TokenizeError};
 use thiserror::Error;
 
 #[inline]
-fn is_sugar_enabled() -> bool { crate::parser::sugar_gate::is_enabled() }
+fn is_sugar_enabled() -> bool {
+    crate::parser::sugar_gate::is_enabled()
+}
 
 // ===== 🔥 Debug Macros =====
 
@@ -48,9 +50,17 @@ macro_rules! must_advance {
         if let Some(ref mut limit) = $parser.debug_fuel {
             if *limit == 0 {
                 eprintln!("🚨 PARSER INFINITE LOOP DETECTED at {}", $location);
-                eprintln!("🔍 Current token: {:?} at line {}", $parser.current_token().token_type, $parser.current_token().line);
-                eprintln!("🔍 Parser position: {}/{}", $parser.current, $parser.tokens.len());
-                return Err($crate::parser::ParseError::InfiniteLoop { 
+                eprintln!(
+                    "🔍 Current token: {:?} at line {}",
+                    $parser.current_token().token_type,
+                    $parser.current_token().line
+                );
+                eprintln!(
+                    "🔍 Parser position: {}/{}",
+                    $parser.current,
+                    $parser.tokens.len()
+                );
+                return Err($crate::parser::ParseError::InfiniteLoop {
                     location: $location.to_string(),
                     token: $parser.current_token().token_type.clone(),
                     line: $parser.current_token().line,
@@ -76,32 +86,42 @@ macro_rules! debug_fuel {
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error("Unexpected token {found:?}, expected {expected} at line {line}")]
-    UnexpectedToken { found: TokenType, expected: String, line: usize },
-    
+    UnexpectedToken {
+        found: TokenType,
+        expected: String,
+        line: usize,
+    },
+
     #[error("Unexpected end of file")]
     UnexpectedEOF,
-    
+
     #[error("Invalid expression at line {line}")]
     InvalidExpression { line: usize },
-    
+
     #[error("Invalid statement at line {line}")]
     InvalidStatement { line: usize },
-    
+
     #[error("Circular dependency detected between static boxes: {cycle}")]
     CircularDependency { cycle: String },
-    
+
     #[error("🚨 Infinite loop detected in parser at {location} - token: {token:?} at line {line}")]
-    InfiniteLoop { location: String, token: TokenType, line: usize },
-    
+    InfiniteLoop {
+        location: String,
+        token: TokenType,
+        line: usize,
+    },
+
     #[error("🔥 Transparency system removed: {suggestion} at line {line}")]
     TransparencySystemRemoved { suggestion: String, line: usize },
-    
-    #[error("Unsupported namespace '{name}' at line {line}. Only 'nyashstd' is supported in Phase 0.")]
+
+    #[error(
+        "Unsupported namespace '{name}' at line {line}. Only 'nyashstd' is supported in Phase 0."
+    )]
     UnsupportedNamespace { name: String, line: usize },
-    
+
     #[error("Expected identifier at line {line}")]
     ExpectedIdentifier { line: usize },
-    
+
     #[error("Tokenize error: {0}")]
     TokenizeError(#[from] TokenizeError),
 }
@@ -111,7 +131,8 @@ pub struct NyashParser {
     pub(super) tokens: Vec<Token>,
     pub(super) current: usize,
     /// 🔥 Static box依存関係追跡（循環依存検出用）
-    pub(super) static_box_dependencies: std::collections::HashMap<String, std::collections::HashSet<String>>,
+    pub(super) static_box_dependencies:
+        std::collections::HashMap<String, std::collections::HashSet<String>>,
     /// 🔥 デバッグ燃料：無限ループ検出用制限値 (None = 無制限)
     pub(super) debug_fuel: Option<usize>,
 }
@@ -121,11 +142,11 @@ impl ParserUtils for NyashParser {
     fn tokens(&self) -> &Vec<Token> {
         &self.tokens
     }
-    
+
     fn current(&self) -> usize {
         self.current
     }
-    
+
     fn current_mut(&mut self) -> &mut usize {
         &mut self.current
     }
@@ -141,106 +162,108 @@ impl NyashParser {
             debug_fuel: Some(100_000), // デフォルト値
         }
     }
-    
+
     /// 文字列からパース (トークナイズ + パース)
     pub fn parse_from_string(input: impl Into<String>) -> Result<ASTNode, ParseError> {
         Self::parse_from_string_with_fuel(input, Some(100_000))
     }
-    
+
     /// 文字列からパース (デバッグ燃料指定版)
     /// fuel: Some(n) = n回まで、None = 無制限
-    pub fn parse_from_string_with_fuel(input: impl Into<String>, fuel: Option<usize>) -> Result<ASTNode, ParseError> {
+    pub fn parse_from_string_with_fuel(
+        input: impl Into<String>,
+        fuel: Option<usize>,
+    ) -> Result<ASTNode, ParseError> {
         let mut tokenizer = crate::tokenizer::NyashTokenizer::new(input);
         let tokens = tokenizer.tokenize()?;
-        
+
         let mut parser = Self::new(tokens);
         parser.debug_fuel = fuel;
         let result = parser.parse();
         result
     }
-    
+
     /// パース実行 - Program ASTを返す
     pub fn parse(&mut self) -> Result<ASTNode, ParseError> {
         self.parse_program()
     }
-    
+
     // ===== パース関数群 =====
-    
+
     /// プログラム全体をパース
     fn parse_program(&mut self) -> Result<ASTNode, ParseError> {
         let mut statements = Vec::new();
         let mut _statement_count = 0;
-        
+
         while !self.is_at_end() {
-            
             // EOF tokenはスキップ
             if matches!(self.current_token().token_type, TokenType::EOF) {
                 break;
             }
-            
+
             // NEWLINE tokenはスキップ（文の区切りとして使用）
             if matches!(self.current_token().token_type, TokenType::NEWLINE) {
                 self.advance();
                 continue;
             }
-            
+
             let statement = self.parse_statement()?;
             statements.push(statement);
             _statement_count += 1;
         }
-        
-        
+
         // 🔥 すべてのstatic box解析後に循環依存検出
         self.check_circular_dependencies()?;
-        
-        Ok(ASTNode::Program { statements, span: Span::unknown() })
+
+        Ok(ASTNode::Program {
+            statements,
+            span: Span::unknown(),
+        })
     }
     // Statement parsing methods are now in statements.rs module
-    
+
     /// 代入文または関数呼び出しをパース
     fn parse_assignment_or_function_call(&mut self) -> Result<ASTNode, ParseError> {
-        
         // まず左辺を式としてパース
         let expr = self.parse_expression()?;
-        
+
         // 次のトークンが = または 複合代入演算子 なら代入文
         if self.match_token(&TokenType::ASSIGN) {
             self.advance(); // consume '='
             let value = Box::new(self.parse_expression()?);
-            
+
             // 左辺が代入可能な形式かチェック
             match &expr {
-                ASTNode::Variable { .. } | 
-                ASTNode::FieldAccess { .. } => {
-                    Ok(ASTNode::Assignment {
-                        target: Box::new(expr),
-                        value,
-                        span: Span::unknown(),
-                    })
-                }
+                ASTNode::Variable { .. } | ASTNode::FieldAccess { .. } => Ok(ASTNode::Assignment {
+                    target: Box::new(expr),
+                    value,
+                    span: Span::unknown(),
+                }),
                 _ => {
                     let line = self.current_token().line;
                     Err(ParseError::InvalidStatement { line })
                 }
             }
-        } else if self.match_token(&TokenType::PLUS_ASSIGN) ||
-                  self.match_token(&TokenType::MINUS_ASSIGN) ||
-                  self.match_token(&TokenType::MUL_ASSIGN) ||
-                  self.match_token(&TokenType::DIV_ASSIGN) {
+        } else if self.match_token(&TokenType::PlusAssign)
+            || self.match_token(&TokenType::MinusAssign)
+            || self.match_token(&TokenType::MulAssign)
+            || self.match_token(&TokenType::DivAssign)
+        {
             if !is_sugar_enabled() {
                 let line = self.current_token().line;
                 return Err(ParseError::UnexpectedToken {
                     found: self.current_token().token_type.clone(),
-                    expected: "enable NYASH_SYNTAX_SUGAR_LEVEL=basic|full for '+=' and friends".to_string(),
+                    expected: "enable NYASH_SYNTAX_SUGAR_LEVEL=basic|full for '+=' and friends"
+                        .to_string(),
                     line,
                 });
             }
             // determine operator
             let op = match &self.current_token().token_type {
-                TokenType::PLUS_ASSIGN => crate::ast::BinaryOperator::Add,
-                TokenType::MINUS_ASSIGN => crate::ast::BinaryOperator::Subtract,
-                TokenType::MUL_ASSIGN => crate::ast::BinaryOperator::Multiply,
-                TokenType::DIV_ASSIGN => crate::ast::BinaryOperator::Divide,
+                TokenType::PlusAssign => crate::ast::BinaryOperator::Add,
+                TokenType::MinusAssign => crate::ast::BinaryOperator::Subtract,
+                TokenType::MulAssign => crate::ast::BinaryOperator::Multiply,
+                TokenType::DivAssign => crate::ast::BinaryOperator::Divide,
                 _ => unreachable!(),
             };
             self.advance(); // consume 'op='
@@ -249,8 +272,17 @@ impl NyashParser {
             match &expr {
                 ASTNode::Variable { .. } | ASTNode::FieldAccess { .. } => {
                     let left_clone = expr.clone();
-                    let value = ASTNode::BinaryOp { operator: op, left: Box::new(left_clone), right: Box::new(rhs), span: Span::unknown() };
-                    Ok(ASTNode::Assignment { target: Box::new(expr), value: Box::new(value), span: Span::unknown() })
+                    let value = ASTNode::BinaryOp {
+                        operator: op,
+                        left: Box::new(left_clone),
+                        right: Box::new(rhs),
+                        span: Span::unknown(),
+                    };
+                    Ok(ASTNode::Assignment {
+                        target: Box::new(expr),
+                        value: Box::new(value),
+                        span: Span::unknown(),
+                    })
                 }
                 _ => {
                     let line = self.current_token().line;
@@ -262,10 +294,10 @@ impl NyashParser {
             Ok(expr)
         }
     }
-    
+
     // Expression parsing methods are now in expressions.rs module
     // Utility methods are now in common.rs module via ParserUtils trait
     // Item parsing methods are now in items.rs module
-    
+
     // ===== 🔥 Static Box循環依存検出 =====
 }

--- a/src/tests/sugar_basic_test.rs
+++ b/src/tests/sugar_basic_test.rs
@@ -18,13 +18,12 @@ fn tokenizer_has_basic_sugar_tokens() {
     let mut t = NyashTokenizer::new("|> ?.? ?? += -= *= /= ..");
     let toks = t.tokenize().unwrap();
     let has = |p: fn(&TokenType) -> bool| -> bool { toks.iter().any(|k| p(&k.token_type)) };
-    assert!(has(|k| matches!(k, TokenType::PIPE_FORWARD)));
-    assert!(has(|k| matches!(k, TokenType::QMARK_DOT)));
-    assert!(has(|k| matches!(k, TokenType::QMARK_QMARK)));
-    assert!(has(|k| matches!(k, TokenType::PLUS_ASSIGN)));
-    assert!(has(|k| matches!(k, TokenType::MINUS_ASSIGN)));
-    assert!(has(|k| matches!(k, TokenType::MUL_ASSIGN)));
-    assert!(has(|k| matches!(k, TokenType::DIV_ASSIGN)));
+    assert!(has(|k| matches!(k, TokenType::PipeForward)));
+    assert!(has(|k| matches!(k, TokenType::QmarkDot)));
+    assert!(has(|k| matches!(k, TokenType::QmarkQmark)));
+    assert!(has(|k| matches!(k, TokenType::PlusAssign)));
+    assert!(has(|k| matches!(k, TokenType::MinusAssign)));
+    assert!(has(|k| matches!(k, TokenType::MulAssign)));
+    assert!(has(|k| matches!(k, TokenType::DivAssign)));
     assert!(has(|k| matches!(k, TokenType::RANGE)));
 }
-

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,12 +1,12 @@
 /*!
  * Nyash Tokenizer - .nyashソースコードをトークン列に変換
- * 
+ *
  * Python版nyashc_v4.pyのNyashTokenizerをRustで完全再実装
  * 正規表現ベース → 高速なcharレベル処理に最適化
  */
 
-use thiserror::Error;
 use crate::grammar::engine;
+use thiserror::Error;
 
 /// トークンの種類を表すenum
 #[derive(Debug, Clone, PartialEq)]
@@ -14,11 +14,11 @@ pub enum TokenType {
     // リテラル
     STRING(String),
     NUMBER(i64),
-    FLOAT(f64),  // 浮動小数点数サポート追加
+    FLOAT(f64), // 浮動小数点数サポート追加
     TRUE,
     FALSE,
-    NULL,        // null リテラル
-    
+    NULL, // null リテラル
+
     // キーワード
     BOX,
     GLOBAL,
@@ -36,68 +36,68 @@ pub enum TokenType {
     PRINT,
     THIS,
     ME,
-    INIT,            // init (初期化ブロック)
-    PACK,            // pack (コンストラクタ - 互換性)
-    BIRTH,           // birth (コンストラクタ)
-    NOWAIT,          // nowait
-    AWAIT,           // await
-    INTERFACE,       // interface
-    COLON,           // : (継承用)
-    INCLUDE,         // include (ファイル読み込み)
-    TRY,             // try
-    CATCH,           // catch
-    FINALLY,         // finally
-    THROW,           // throw
-    LOCAL,           // local (一時変数宣言)
-    STATIC,          // static (静的メソッド)
-    OUTBOX,          // outbox (所有権移転変数)
-    NOT,             // not (否定演算子)
-    OVERRIDE,        // override (明示的オーバーライド)
-    FROM,            // from (親メソッド呼び出し)
-    WEAK,            // weak (弱参照修飾子)
-    USING,           // using (名前空間インポート)
-    
+    INIT,      // init (初期化ブロック)
+    PACK,      // pack (コンストラクタ - 互換性)
+    BIRTH,     // birth (コンストラクタ)
+    NOWAIT,    // nowait
+    AWAIT,     // await
+    INTERFACE, // interface
+    COLON,     // : (継承用)
+    INCLUDE,   // include (ファイル読み込み)
+    TRY,       // try
+    CATCH,     // catch
+    FINALLY,   // finally
+    THROW,     // throw
+    LOCAL,     // local (一時変数宣言)
+    STATIC,    // static (静的メソッド)
+    OUTBOX,    // outbox (所有権移転変数)
+    NOT,       // not (否定演算子)
+    OVERRIDE,  // override (明示的オーバーライド)
+    FROM,      // from (親メソッド呼び出し)
+    WEAK,      // weak (弱参照修飾子)
+    USING,     // using (名前空間インポート)
+
     // 演算子 (長いものから先に定義)
-    ARROW,           // >> (legacy arrow)
-    FAT_ARROW,       // => (peek arms)
-    EQUALS,          // ==
-    NotEquals,       // !=
-    LessEquals,      // <=
-    GreaterEquals,   // >=
-    AND,             // && または and
-    OR,              // || または or
+    ARROW,         // >> (legacy arrow)
+    FatArrow,      // => (peek arms)
+    EQUALS,        // ==
+    NotEquals,     // !=
+    LessEquals,    // <=
+    GreaterEquals, // >=
+    AND,           // && または and
+    OR,            // || または or
     // Phase 12.7-B 基本糖衣: 2文字演算子（最長一致優先）
-    PIPE_FORWARD,    // |>
-    QMARK_DOT,       // ?.
-    QMARK_QMARK,     // ??
-    PLUS_ASSIGN,     // +=
-    MINUS_ASSIGN,    // -=
-    MUL_ASSIGN,      // *=
-    DIV_ASSIGN,      // /=
-    RANGE,           // ..
-    LESS,            // <
-    GREATER,         // >
-    ASSIGN,          // =
-    PLUS,            // +
-    MINUS,           // -
-    MULTIPLY,        // *
-    DIVIDE,          // /
-    MODULO,          // %
-    
+    PipeForward, // |>
+    QmarkDot,    // ?.
+    QmarkQmark,  // ??
+    PlusAssign,  // +=
+    MinusAssign, // -=
+    MulAssign,   // *=
+    DivAssign,   // /=
+    RANGE,       // ..
+    LESS,        // <
+    GREATER,     // >
+    ASSIGN,      // =
+    PLUS,        // +
+    MINUS,       // -
+    MULTIPLY,    // *
+    DIVIDE,      // /
+    MODULO,      // %
+
     // 記号
-    DOT,             // .
-    DOUBLE_COLON,    // :: (Parent::method) - P1用（定義のみ）
-    LPAREN,          // (
-    RPAREN,          // )
-    LBRACE,          // {
-    RBRACE,          // }
-    COMMA,           // ,
-    QUESTION,        // ? (postfix result propagation)
-    NEWLINE,         // \n
-    
+    DOT,         // .
+    DoubleColon, // :: (Parent::method) - P1用（定義のみ）
+    LPAREN,      // (
+    RPAREN,      // )
+    LBRACE,      // {
+    RBRACE,      // }
+    COMMA,       // ,
+    QUESTION,    // ? (postfix result propagation)
+    NEWLINE,     // \n
+
     // 識別子
     IDENTIFIER(String),
-    
+
     // 特殊
     EOF,
 }
@@ -112,7 +112,11 @@ pub struct Token {
 
 impl Token {
     pub fn new(token_type: TokenType, line: usize, column: usize) -> Self {
-        Self { token_type, line, column }
+        Self {
+            token_type,
+            line,
+            column,
+        }
     }
 }
 
@@ -120,14 +124,18 @@ impl Token {
 #[derive(Error, Debug)]
 pub enum TokenizeError {
     #[error("Unexpected character '{char}' at line {line}, column {column}")]
-    UnexpectedCharacter { char: char, line: usize, column: usize },
-    
+    UnexpectedCharacter {
+        char: char,
+        line: usize,
+        column: usize,
+    },
+
     #[error("Unterminated string literal at line {line}")]
     UnterminatedString { line: usize },
-    
+
     #[error("Invalid number format at line {line}")]
     InvalidNumber { line: usize },
-    
+
     #[error("Comment not closed at line {line}")]
     UnterminatedComment { line: usize },
 }
@@ -151,71 +159,71 @@ impl NyashTokenizer {
             column: 1,
         }
     }
-    
+
     /// 完全なトークナイズを実行
     pub fn tokenize(&mut self) -> Result<Vec<Token>, TokenizeError> {
         let mut tokens = Vec::new();
-        
+
         while !self.is_at_end() {
             // 空白をスキップ
             self.skip_whitespace();
-            
+
             if self.is_at_end() {
                 break;
             }
-            
+
             // 次のトークンを読み取り
             let token = self.tokenize_next()?;
             tokens.push(token);
         }
-        
+
         // EOF トークンを追加
         tokens.push(Token::new(TokenType::EOF, self.line, self.column));
-        
+
         Ok(tokens)
     }
-    
+
     /// 次の一つのトークンを読み取り
     fn tokenize_next(&mut self) -> Result<Token, TokenizeError> {
         let start_line = self.line;
         let start_column = self.column;
-        
+
         match self.current_char() {
             // 2文字（またはそれ以上）の演算子は最長一致で先に判定
             Some('|') if self.peek_char() == Some('>') => {
                 self.advance();
                 self.advance();
-                return Ok(Token::new(TokenType::PIPE_FORWARD, start_line, start_column));
+                return Ok(Token::new(TokenType::PipeForward, start_line, start_column));
             }
             Some('?') if self.peek_char() == Some('.') => {
                 self.advance();
                 self.advance();
-                return Ok(Token::new(TokenType::QMARK_DOT, start_line, start_column));
+                return Ok(Token::new(TokenType::QmarkDot, start_line, start_column));
             }
             Some('?') if self.peek_char() == Some('?') => {
                 self.advance();
                 self.advance();
-                return Ok(Token::new(TokenType::QMARK_QMARK, start_line, start_column));
+                return Ok(Token::new(TokenType::QmarkQmark, start_line, start_column));
             }
             Some('+') if self.peek_char() == Some('=') => {
                 self.advance();
                 self.advance();
-                return Ok(Token::new(TokenType::PLUS_ASSIGN, start_line, start_column));
+                return Ok(Token::new(TokenType::PlusAssign, start_line, start_column));
             }
             Some('-') if self.peek_char() == Some('=') => {
                 self.advance();
                 self.advance();
-                return Ok(Token::new(TokenType::MINUS_ASSIGN, start_line, start_column));
+                return Ok(Token::new(TokenType::MinusAssign, start_line, start_column));
             }
             Some('*') if self.peek_char() == Some('=') => {
                 self.advance();
                 self.advance();
-                return Ok(Token::new(TokenType::MUL_ASSIGN, start_line, start_column));
+                return Ok(Token::new(TokenType::MulAssign, start_line, start_column));
             }
             Some('/') if self.peek_char() == Some('=') => {
                 self.advance();
                 self.advance();
-                return Ok(Token::new(TokenType::DIV_ASSIGN, start_line, start_column));
+                return Ok(Token::new(TokenType::DivAssign, start_line, start_column));
             }
             Some('.') if self.peek_char() == Some('.') => {
                 self.advance();
@@ -224,7 +232,11 @@ impl NyashTokenizer {
             }
             Some('"') => {
                 let string_value = self.read_string()?;
-                Ok(Token::new(TokenType::STRING(string_value), start_line, start_column))
+                Ok(Token::new(
+                    TokenType::STRING(string_value),
+                    start_line,
+                    start_column,
+                ))
             }
             Some(c) if c.is_ascii_digit() => {
                 let token_type = self.read_numeric_literal()?;
@@ -241,7 +253,7 @@ impl NyashTokenizer {
             }
             Some('#') => {
                 self.skip_line_comment();
-                self.skip_whitespace(); // コメント後の空白もスキップ  
+                self.skip_whitespace(); // コメント後の空白もスキップ
                 return self.tokenize_next();
             }
             Some('>') if self.peek_char() == Some('>') => {
@@ -252,12 +264,12 @@ impl NyashTokenizer {
             Some(':') if self.peek_char() == Some(':') => {
                 self.advance();
                 self.advance();
-                Ok(Token::new(TokenType::DOUBLE_COLON, start_line, start_column))
+                Ok(Token::new(TokenType::DoubleColon, start_line, start_column))
             }
             Some('=') if self.peek_char() == Some('>') => {
                 self.advance();
                 self.advance();
-                Ok(Token::new(TokenType::FAT_ARROW, start_line, start_column))
+                Ok(Token::new(TokenType::FatArrow, start_line, start_column))
             }
             Some('=') if self.peek_char() == Some('=') => {
                 self.advance();
@@ -277,7 +289,11 @@ impl NyashTokenizer {
             Some('>') if self.peek_char() == Some('=') => {
                 self.advance();
                 self.advance();
-                Ok(Token::new(TokenType::GreaterEquals, start_line, start_column))
+                Ok(Token::new(
+                    TokenType::GreaterEquals,
+                    start_line,
+                    start_column,
+                ))
             }
             Some('&') if self.peek_char() == Some('&') => {
                 self.advance();
@@ -357,32 +373,28 @@ impl NyashTokenizer {
                 self.advance();
                 Ok(Token::new(TokenType::NEWLINE, start_line, start_column))
             }
-            Some(c) => {
-                Err(TokenizeError::UnexpectedCharacter {
-                    char: c,
-                    line: self.line,
-                    column: self.column,
-                })
-            }
-            None => {
-                Ok(Token::new(TokenType::EOF, self.line, self.column))
-            }
+            Some(c) => Err(TokenizeError::UnexpectedCharacter {
+                char: c,
+                line: self.line,
+                column: self.column,
+            }),
+            None => Ok(Token::new(TokenType::EOF, self.line, self.column)),
         }
     }
-    
+
     /// 文字列リテラルを読み取り
     fn read_string(&mut self) -> Result<String, TokenizeError> {
         let start_line = self.line;
         self.advance(); // 開始の '"' をスキップ
-        
+
         let mut string_value = String::new();
-        
+
         while let Some(c) = self.current_char() {
             if c == '"' {
                 self.advance(); // 終了の '"' をスキップ
                 return Ok(string_value);
             }
-            
+
             // エスケープ文字の処理
             if c == '\\' {
                 self.advance();
@@ -401,25 +413,28 @@ impl NyashTokenizer {
             } else {
                 string_value.push(c);
             }
-            
+
             self.advance();
         }
-        
+
         Err(TokenizeError::UnterminatedString { line: start_line })
     }
-    
+
     /// 数値リテラル（整数または浮動小数点数）を読み取り
     fn read_numeric_literal(&mut self) -> Result<TokenType, TokenizeError> {
         let start_line = self.line;
         let mut number_str = String::new();
         let mut has_dot = false;
-        
+
         // 整数部分を読み取り
         while let Some(c) = self.current_char() {
             if c.is_ascii_digit() {
                 number_str.push(c);
                 self.advance();
-            } else if c == '.' && !has_dot && self.peek_char().map_or(false, |ch| ch.is_ascii_digit()) {
+            } else if c == '.'
+                && !has_dot
+                && self.peek_char().map_or(false, |ch| ch.is_ascii_digit())
+            {
                 // 小数点の後に数字が続く場合のみ受け入れる
                 has_dot = true;
                 number_str.push(c);
@@ -428,24 +443,26 @@ impl NyashTokenizer {
                 break;
             }
         }
-        
+
         if has_dot {
             // 浮動小数点数として解析
-            number_str.parse::<f64>()
+            number_str
+                .parse::<f64>()
                 .map(TokenType::FLOAT)
                 .map_err(|_| TokenizeError::InvalidNumber { line: start_line })
         } else {
             // 整数として解析
-            number_str.parse::<i64>()
+            number_str
+                .parse::<i64>()
                 .map(TokenType::NUMBER)
                 .map_err(|_| TokenizeError::InvalidNumber { line: start_line })
         }
     }
-    
+
     /// キーワードまたは識別子を読み取り
     fn read_keyword_or_identifier(&mut self) -> TokenType {
         let mut identifier = String::new();
-        
+
         while let Some(c) = self.current_char() {
             if c.is_alphanumeric() || c == '_' {
                 identifier.push(c);
@@ -454,8 +471,8 @@ impl NyashTokenizer {
                 break;
             }
         }
-        
-    // キーワードチェック
+
+        // キーワードチェック
         let tok = match identifier.as_str() {
             "box" => TokenType::BOX,
             "global" => TokenType::GLOBAL,
@@ -508,12 +525,18 @@ impl NyashTokenizer {
             let kw = engine::get().is_keyword_str(&identifier);
             match (&tok, kw) {
                 (TokenType::IDENTIFIER(_), Some(name)) => {
-                    eprintln!("[GRAMMAR-DIFF] tokenizer=IDENT, grammar=KEYWORD({}) word='{}'", name, identifier);
+                    eprintln!(
+                        "[GRAMMAR-DIFF] tokenizer=IDENT, grammar=KEYWORD({}) word='{}'",
+                        name, identifier
+                    );
                 }
                 (TokenType::IDENTIFIER(_), None) => {}
                 // tokenizerがキーワード、grammarが未定義
                 (t, None) if !matches!(t, TokenType::IDENTIFIER(_)) => {
-                    eprintln!("[GRAMMAR-DIFF] tokenizer=KEYWORD, grammar=IDENT word='{}'", identifier);
+                    eprintln!(
+                        "[GRAMMAR-DIFF] tokenizer=KEYWORD, grammar=IDENT word='{}'",
+                        identifier
+                    );
                 }
                 _ => {}
             }
@@ -521,7 +544,7 @@ impl NyashTokenizer {
 
         tok
     }
-    
+
     /// 行コメントをスキップ
     fn skip_line_comment(&mut self) {
         while let Some(c) = self.current_char() {
@@ -531,7 +554,7 @@ impl NyashTokenizer {
             self.advance();
         }
     }
-    
+
     /// 空白文字をスキップ（改行は除く：改行はNEWLINEトークンとして扱う）
     fn skip_whitespace(&mut self) {
         while let Some(c) = self.current_char() {
@@ -542,17 +565,17 @@ impl NyashTokenizer {
             }
         }
     }
-    
+
     /// 現在の文字を取得
     fn current_char(&self) -> Option<char> {
         self.input.get(self.position).copied()
     }
-    
+
     /// 次の文字を先読み
     fn peek_char(&self) -> Option<char> {
         self.input.get(self.position + 1).copied()
     }
-    
+
     /// 位置を1つ進める
     fn advance(&mut self) {
         if let Some(c) = self.current_char() {
@@ -565,7 +588,7 @@ impl NyashTokenizer {
             self.position += 1;
         }
     }
-    
+
     /// 入力の終端に達したかチェック
     fn is_at_end(&self) -> bool {
         self.position >= self.input.len()
@@ -577,12 +600,12 @@ impl NyashTokenizer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_simple_tokens() {
         let mut tokenizer = NyashTokenizer::new("box new = + - *");
         let tokens = tokenizer.tokenize().unwrap();
-        
+
         assert_eq!(tokens.len(), 7); // 6 tokens + EOF
         assert_eq!(tokens[0].token_type, TokenType::BOX);
         assert_eq!(tokens[1].token_type, TokenType::NEW);
@@ -592,24 +615,24 @@ mod tests {
         assert_eq!(tokens[5].token_type, TokenType::MULTIPLY);
         assert_eq!(tokens[6].token_type, TokenType::EOF);
     }
-    
+
     #[test]
     fn test_string_literal() {
         let mut tokenizer = NyashTokenizer::new(r#""Hello, World!""#);
         let tokens = tokenizer.tokenize().unwrap();
-        
+
         assert_eq!(tokens.len(), 2); // STRING + EOF
         match &tokens[0].token_type {
             TokenType::STRING(s) => assert_eq!(s, "Hello, World!"),
             _ => panic!("Expected STRING token"),
         }
     }
-    
+
     #[test]
     fn test_number_literal() {
         let mut tokenizer = NyashTokenizer::new("42 123 0");
         let tokens = tokenizer.tokenize().unwrap();
-        
+
         assert_eq!(tokens.len(), 4); // 3 numbers + EOF
         match &tokens[0].token_type {
             TokenType::NUMBER(n) => assert_eq!(*n, 42),
@@ -624,12 +647,12 @@ mod tests {
             _ => panic!("Expected NUMBER token"),
         }
     }
-    
+
     #[test]
     fn test_identifier() {
         let mut tokenizer = NyashTokenizer::new("test_var myBox getValue");
         let tokens = tokenizer.tokenize().unwrap();
-        
+
         assert_eq!(tokens.len(), 4); // 3 identifiers + EOF
         match &tokens[0].token_type {
             TokenType::IDENTIFIER(s) => assert_eq!(s, "test_var"),
@@ -644,12 +667,12 @@ mod tests {
             _ => panic!("Expected IDENTIFIER token"),
         }
     }
-    
+
     #[test]
     fn test_operators() {
         let mut tokenizer = NyashTokenizer::new(">> == != <= >= < >");
         let tokens = tokenizer.tokenize().unwrap();
-        
+
         assert_eq!(tokens[0].token_type, TokenType::ARROW);
         assert_eq!(tokens[1].token_type, TokenType::EQUALS);
         assert_eq!(tokens[2].token_type, TokenType::NotEquals);
@@ -658,7 +681,7 @@ mod tests {
         assert_eq!(tokens[5].token_type, TokenType::LESS);
         assert_eq!(tokens[6].token_type, TokenType::GREATER);
     }
-    
+
     #[test]
     fn test_complex_code() {
         let code = r#"
@@ -673,10 +696,10 @@ mod tests {
         obj = new TestBox()
         obj.value = "test123"
         "#;
-        
+
         let mut tokenizer = NyashTokenizer::new(code);
         let tokens = tokenizer.tokenize().unwrap();
-        
+
         // 基本的なトークンがある事を確認
         let token_types: Vec<_> = tokens.iter().map(|t| &t.token_type).collect();
         assert!(token_types.contains(&&TokenType::BOX));
@@ -685,7 +708,7 @@ mod tests {
         assert!(token_types.contains(&&TokenType::RETURN));
         assert!(token_types.contains(&&TokenType::DOT));
     }
-    
+
     #[test]
     fn test_line_numbers() {
         let code = "box\ntest\nvalue";
@@ -693,34 +716,38 @@ mod tests {
         let tokens = tokenizer.tokenize().unwrap();
 
         // NEWLINEトークンを除外して確認
-        let non_newline: Vec<&Token> = tokens.iter().filter(|t| !matches!(t.token_type, TokenType::NEWLINE)).collect();
+        let non_newline: Vec<&Token> = tokens
+            .iter()
+            .filter(|t| !matches!(t.token_type, TokenType::NEWLINE))
+            .collect();
         assert_eq!(non_newline[0].line, 1); // box
         assert_eq!(non_newline[1].line, 2); // test
         assert_eq!(non_newline[2].line, 3); // value
     }
-    
+
     #[test]
     fn test_comments() {
         let code = r#"box Test // this is a comment
 # this is also a comment
 value"#;
-        
+
         let mut tokenizer = NyashTokenizer::new(code);
         let tokens = tokenizer.tokenize().unwrap();
-        
+
         // コメントは除外されている
-        let token_types: Vec<_> = tokens.iter()
+        let token_types: Vec<_> = tokens
+            .iter()
             .filter(|t| !matches!(t.token_type, TokenType::NEWLINE))
             .map(|t| &t.token_type)
             .collect();
         assert_eq!(token_types.len(), 4); // box, Test, value, EOF
     }
-    
+
     #[test]
     fn test_error_handling() {
         let mut tokenizer = NyashTokenizer::new("@#$%");
         let result = tokenizer.tokenize();
-        
+
         assert!(result.is_err());
         match result {
             Err(TokenizeError::UnexpectedCharacter { char, line, column }) => {
@@ -739,14 +766,30 @@ value"#;
         // 分かりやすく固めたケース
         let mut t2 = NyashTokenizer::new("|> ?.? ?? += -= *= /= ..");
         let toks = t2.tokenize().unwrap();
-        assert!(toks.iter().any(|k| matches!(k.token_type, TokenType::PIPE_FORWARD)));
-        assert!(toks.iter().any(|k| matches!(k.token_type, TokenType::QMARK_DOT)));
-        assert!(toks.iter().any(|k| matches!(k.token_type, TokenType::QMARK_QMARK)));
-        assert!(toks.iter().any(|k| matches!(k.token_type, TokenType::PLUS_ASSIGN)));
-        assert!(toks.iter().any(|k| matches!(k.token_type, TokenType::MINUS_ASSIGN)));
-        assert!(toks.iter().any(|k| matches!(k.token_type, TokenType::MUL_ASSIGN)));
-        assert!(toks.iter().any(|k| matches!(k.token_type, TokenType::DIV_ASSIGN)));
-        assert!(toks.iter().any(|k| matches!(k.token_type, TokenType::RANGE)));
+        assert!(toks
+            .iter()
+            .any(|k| matches!(k.token_type, TokenType::PipeForward)));
+        assert!(toks
+            .iter()
+            .any(|k| matches!(k.token_type, TokenType::QmarkDot)));
+        assert!(toks
+            .iter()
+            .any(|k| matches!(k.token_type, TokenType::QmarkQmark)));
+        assert!(toks
+            .iter()
+            .any(|k| matches!(k.token_type, TokenType::PlusAssign)));
+        assert!(toks
+            .iter()
+            .any(|k| matches!(k.token_type, TokenType::MinusAssign)));
+        assert!(toks
+            .iter()
+            .any(|k| matches!(k.token_type, TokenType::MulAssign)));
+        assert!(toks
+            .iter()
+            .any(|k| matches!(k.token_type, TokenType::DivAssign)));
+        assert!(toks
+            .iter()
+            .any(|k| matches!(k.token_type, TokenType::RANGE)));
     }
 
     #[test]
@@ -755,9 +798,9 @@ value"#;
         let mut t = NyashTokenizer::new("?? ? ?. .. .");
         let toks = t.tokenize().unwrap();
         let kinds: Vec<&TokenType> = toks.iter().map(|k| &k.token_type).collect();
-        assert!(matches!(kinds[0], TokenType::QMARK_QMARK));
+        assert!(matches!(kinds[0], TokenType::QmarkQmark));
         assert!(matches!(kinds[1], TokenType::QUESTION));
-        assert!(matches!(kinds[2], TokenType::QMARK_DOT));
+        assert!(matches!(kinds[2], TokenType::QmarkDot));
         assert!(matches!(kinds[3], TokenType::RANGE));
         assert!(matches!(kinds[4], TokenType::DOT));
     }


### PR DESCRIPTION
## Summary
- gate AOT object emission behind `cranelift-jit`
- clean up unused imports in several boxes
- rename tokenizer enums to CamelCase and update parser/tests/docs

## Testing
- `env LLVM_SYS_181_PREFIX=/usr/lib/llvm-18 cargo check --features llvm` *(fails: emitted 146 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c26cf9dc488333a56338e1f9230c66